### PR TITLE
ci: add aggregated jacoco coverage report and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,16 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v6
-    
+
     - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
@@ -23,5 +26,28 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
 
-    - name: Build with Gradle
-      run: ./gradlew check
+    - name: Build and test
+      run: ./gradlew check jacocoAggregatedReport
+
+    - name: Generate JaCoCo coverage badge
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      id: jacoco
+      uses: cicirello/jacoco-badge-generator@v2
+      with:
+        jacoco-csv-file: build/reports/jacoco/aggregated/jacoco.xml
+        badges-directory: .github/badges
+        generate-coverage-badge: true
+        generate-branches-badge: true
+        coverage-badge-filename: jacoco.svg
+        branches-badge-filename: branches.svg
+
+    - name: Commit coverage badges
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      run: |
+        if [ -n "$(git status --porcelain .github/badges)" ]; then
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/badges
+          git commit -m "ci: update coverage badges [skip ci]"
+          git push
+        fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sanitizer-Lib
 
+[![CI](https://github.com/rabinarayanpatra/sanitizer-lib/actions/workflows/ci.yml/badge.svg)](https://github.com/rabinarayanpatra/sanitizer-lib/actions/workflows/ci.yml)
+[![Coverage](https://raw.githubusercontent.com/rabinarayanpatra/sanitizer-lib/master/.github/badges/jacoco.svg)](https://github.com/rabinarayanpatra/sanitizer-lib/actions/workflows/ci.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.rabinarayanpatra.sanitizer/sanitizer-core.svg)](https://central.sonatype.com/namespace/io.github.rabinarayanpatra.sanitizer)
 [![Javadoc](https://img.shields.io/badge/javadoc-online-blue.svg)](https://rabinarayanpatra.github.io/sanitizer-lib/javadoc/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     java
+    jacoco
     `maven-publish`
     id("io.spring.dependency-management") version "1.1.7"
     id("com.diffplug.spotless") version "8.4.0"
@@ -92,5 +93,29 @@ subprojects {
             trimTrailingWhitespace()
             endWithNewline()
         }
+    }
+}
+
+// Aggregated JaCoCo coverage report across all subprojects.
+// Run with: ./gradlew test jacocoAggregatedReport
+tasks.register<JacocoReport>("jacocoAggregatedReport") {
+    group = "verification"
+    description = "Aggregates JaCoCo coverage reports from all subprojects."
+
+    dependsOn(subprojects.map { it.tasks.withType<Test>() })
+
+    val reports = subprojects.flatMap { sub ->
+        sub.tasks.withType<JacocoReport>()
+    }
+
+    executionData.setFrom(reports.flatMap { it.executionData.files })
+    sourceDirectories.setFrom(reports.flatMap { it.sourceDirectories.files })
+    classDirectories.setFrom(reports.flatMap { it.classDirectories.files })
+
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+        xml.outputLocation.set(layout.buildDirectory.file("reports/jacoco/aggregated/jacoco.xml"))
+        html.outputLocation.set(layout.buildDirectory.dir("reports/jacoco/aggregated/html"))
     }
 }


### PR DESCRIPTION
## Summary
- Add a root-level `jacocoAggregatedReport` Gradle task that combines coverage across `sanitizer-core`, `sanitizer-spring`, and `sanitizer-jpa` into a single XML/HTML report
- CI now runs the aggregated report on every build
- On `master` pushes, CI generates coverage and branch badges via `cicirello/jacoco-badge-generator` and commits them to `.github/badges/`
- README references the new badges (Coverage + CI status)

Local run shows ~95% instruction / ~93% branch coverage.

## Test plan
- [ ] CI build is green on this PR
- [ ] After merge, CI commits `.github/badges/jacoco.svg` and `.github/badges/branches.svg` to master
- [ ] README badge renders the actual coverage number

Assisted by AI.