### PR TITLE
ci: switch coverage reporting to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ "master" ]
 
-permissions:
-  contents: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,25 +26,9 @@ jobs:
     - name: Build and test
       run: ./gradlew check jacocoAggregatedReport
 
-    - name: Generate JaCoCo coverage badge
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      id: jacoco
-      uses: cicirello/jacoco-badge-generator@v2
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
       with:
-        jacoco-csv-file: build/reports/jacoco/aggregated/jacoco.xml
-        badges-directory: .github/badges
-        generate-coverage-badge: true
-        generate-branches-badge: true
-        coverage-badge-filename: jacoco.svg
-        branches-badge-filename: branches.svg
-
-    - name: Commit coverage badges
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      run: |
-        if [ -n "$(git status --porcelain .github/badges)" ]; then
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .github/badges
-          git commit -m "ci: update coverage badges [skip ci]"
-          git push
-        fi
+        files: build/reports/jacoco/aggregated/jacoco.xml
+        fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sanitizer-Lib
 
 [![CI](https://github.com/rabinarayanpatra/sanitizer-lib/actions/workflows/ci.yml/badge.svg)](https://github.com/rabinarayanpatra/sanitizer-lib/actions/workflows/ci.yml)
-[![Coverage](https://raw.githubusercontent.com/rabinarayanpatra/sanitizer-lib/master/.github/badges/jacoco.svg)](https://github.com/rabinarayanpatra/sanitizer-lib/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/rabinarayanpatra/sanitizer-lib/branch/master/graph/badge.svg)](https://codecov.io/gh/rabinarayanpatra/sanitizer-lib)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.rabinarayanpatra.sanitizer/sanitizer-core.svg)](https://central.sonatype.com/namespace/io.github.rabinarayanpatra.sanitizer)
 [![Javadoc](https://img.shields.io/badge/javadoc-online-blue.svg)](https://rabinarayanpatra.github.io/sanitizer-lib/javadoc/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
Replace the badge-generator + commit-back approach with codecov.io upload via codecov-action@v5. This is the standard approach used by Mockito, AssertJ, Resilience4j, and most Java OSS libraries:

  - No artifacts committed back to the repo
  - Hosted badge with trends and PR comments
  - Per-PR coverage diff
  - Token read from CODECOV_TOKEN secret (optional for public repos)

Adds codecov.yml with reasonable defaults: 70-100% range, 80% patch target, and quiet PR comments.

Assisted by AI.