### PR TITLE
docs: list SentenceCaseSanitizer in README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 - **Configurable sanitizers** — `ConfigurableFieldSanitizer<T>` base class with `params` attribute on `@Sanitize` for key-value configuration
 - `TruncateSanitizer` — configurable string truncation with optional suffix (`maxLength`, `suffix` params)
+- `SentenceCaseSanitizer` - capitalizes only the first character and lowercases the rest
 - `RemoveNonPrintableSanitizer` bean registered in Spring autoconfiguration (was missing)
 - Java records detection — throws `UnsupportedOperationException` with clear guidance instead of silent failure
 - GitHub Actions workflow for publishing Javadoc to GitHub Pages on release
 - Dependabot configuration for automated Gradle and GitHub Actions dependency updates
-- README now lists all 17 built-in sanitizers with descriptions
+- README now lists all 18 built-in sanitizers with descriptions
 - README section documenting configurable sanitizer usage
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Sanitizer-Lib is an enterprise-grade input sanitization framework for Java appli
 | `LowerCaseSanitizer` | Normalizes text to lowercase |
 | `UpperCaseSanitizer` | Normalizes text to uppercase |
 | `TitleCaseSanitizer` | Capitalizes the first character of each word |
+| `SentenceCaseSanitizer` | Capitalizes only the first character, lowercases the rest |
 | `CollapseWhitespaceSanitizer` | Trims and collapses internal whitespace to a single space |
 | `CreditCardMaskSanitizer` | Secures card numbers by displaying only the last four digits |
 | `SSNMaskSanitizer` | Masks U.S. SSN, revealing only the last four digits |


### PR DESCRIPTION
## Summary
- Adds `SentenceCaseSanitizer` row to the built-in sanitizer table in README (was missing despite shipping in 1.1.0).
- Adds a corresponding entry under 1.1.0 Added in CHANGELOG.
- Corrects "17 built-in sanitizers" to "18".

## Test plan
- [x] `./gradlew test` passes locally
- [ ] CI green on PR