### PR TITLE
feat: v1.2.0 records support and recursive traversal engine

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           mkdir -p site/javadoc
           cp docs/index.html site/index.html
-          for module in sanitizer-core sanitizer-spring sanitizer-jpa; do
+          for module in sanitizer-core sanitizer-spring sanitizer-jpa sanitizer-jpa-spring; do
             if [ -d "$module/build/docs/javadoc" ]; then
               cp -r "$module/build/docs/javadoc" "site/javadoc/$module"
             fi
@@ -72,6 +72,7 @@ jobs:
               <li><a href="sanitizer-core/">sanitizer-core</a> — Core API &amp; Built-in Sanitizers</li>
               <li><a href="sanitizer-spring/">sanitizer-spring</a> — Spring Boot Integration</li>
               <li><a href="sanitizer-jpa/">sanitizer-jpa</a> — JPA Integration</li>
+              <li><a href="sanitizer-jpa-spring/">sanitizer-jpa-spring</a> — Spring Boot starter wiring Hibernate-aware safety checks into the JPA entity listener</li>
             </ul>
           </body>
           </html>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.0] - 2026-06-06
+
+### Added
+- Java records support via new `SanitizationUtils.applyAndReturn(T)` entry point.
+- Opt-in recursive traversal via `@Sanitize(cascade = true)` for nested objects, records, collections, and maps.
+- `TraversalSafetyChecker` interface for pluggable graph-walk gating.
+- New `sanitizer-jpa-spring` module providing `HibernateSafetyChecker` that skips non-initialized lazy JPA associations.
+- SLF4J logging in the traversal engine at DEBUG/TRACE levels.
+
+### Changed
+- `@Sanitize.using()` now defaults to `{}` so a field can opt in to cascade without supplying a self-sanitizer.
+- `SanitizationUtils.apply(record)` throws `IllegalArgumentException` (was `UnsupportedOperationException`) and recommends `applyAndReturn`.
+
+### Compatibility
+- All existing POJO behavior is bit-identical. Cascade is strictly opt-in in this release.
+- The default cascade flag will flip on in v2.0.0 along with a new `@SanitizeIgnore` opt-out annotation.
+
 ## [1.1.0] - 2026-04-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Sanitizer-Lib is an enterprise-grade input sanitization framework for Java appli
   - `SanitizationEntityListener` automatically invoked during `@PrePersist` and `@PreUpdate` lifecycle events
   - Seamless integration with existing entity models
 
+- **JPA + Spring Boot starter** (`sanitizer-jpa-spring`)
+  - Spring Boot starter wiring Hibernate-aware safety checks into the JPA entity listener (skips lazy associations)
+
 ### Architecture
 
 The library follows a modular design with clear separation of concerns:
@@ -60,6 +63,7 @@ The library follows a modular design with clear separation of concerns:
 | **sanitizer-core** | Core API, annotations, utilities, and standard sanitizers |
 | **sanitizer-spring** | Spring Boot integration with autoconfiguration support |
 | **sanitizer-jpa** | JPA entity lifecycle integration |
+| **sanitizer-jpa-spring** | Spring Boot starter wiring Hibernate-aware safety checks into the JPA entity listener (skips lazy associations) |
 
 ## Technical Requirements
 
@@ -77,13 +81,13 @@ The library follows a modular design with clear separation of concerns:
 <dependency>
     <groupId>io.github.rabinarayanpatra.sanitizer</groupId>
     <artifactId>sanitizer-spring</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 </dependency>
 ```
 
 **Gradle (Kotlin DSL):**
 ```kotlin
-implementation("io.github.rabinarayanpatra.sanitizer:sanitizer-spring:1.1.0")
+implementation("io.github.rabinarayanpatra.sanitizer:sanitizer-spring:1.2.0")
 ```
 
 #### JPA Integration (Optional)
@@ -92,13 +96,30 @@ implementation("io.github.rabinarayanpatra.sanitizer:sanitizer-spring:1.1.0")
 <dependency>
     <groupId>io.github.rabinarayanpatra.sanitizer</groupId>
     <artifactId>sanitizer-jpa</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 </dependency>
 ```
 
 **Gradle (Kotlin DSL):**
 ```kotlin
-implementation("io.github.rabinarayanpatra.sanitizer:sanitizer-jpa:1.1.0")
+implementation("io.github.rabinarayanpatra.sanitizer:sanitizer-jpa:1.2.0")
+```
+
+#### JPA + Spring Boot Starter (Optional)
+
+Spring Boot starter wiring Hibernate-aware safety checks into the JPA entity listener (skips lazy associations).
+
+```xml
+<dependency>
+    <groupId>io.github.rabinarayanpatra.sanitizer</groupId>
+    <artifactId>sanitizer-jpa-spring</artifactId>
+    <version>1.2.0</version>
+</dependency>
+```
+
+**Gradle (Kotlin DSL):**
+```kotlin
+implementation("io.github.rabinarayanpatra.sanitizer:sanitizer-jpa-spring:1.2.0")
 ```
 
 ## Implementation Examples
@@ -174,6 +195,26 @@ public class MaskSanitizer extends ConfigurableFieldSanitizer<String> {
 
 Usage: `@Sanitize(using = MaskSanitizer.class, params = "reveal=6,character=X")`
 
+## Recursive sanitization (1.2.0+)
+
+Opt in to recursive traversal of nested objects, records, collections, and maps with `@Sanitize(cascade = true)`. Java records require a different entry point because they are immutable: `SanitizationUtils.applyAndReturn(T)` returns a new instance with sanitized component values.
+
+```java
+record OrderDto(
+        @Sanitize(using = TrimSanitizer.class) String reference,
+        @Sanitize(cascade = true) CustomerDto customer,
+        @Sanitize(cascade = true) List<LineItem> items) {}
+
+// Records: must use applyAndReturn — it returns a new instance.
+OrderDto sanitized = SanitizationUtils.applyAndReturn(rawOrder);
+
+// POJOs: apply mutates in place; applyAndReturn also works and returns
+// the same reference.
+SanitizationUtils.apply(somePojo);
+```
+
+Cascade is strictly opt-in in v1.2.0. The default flips on in v2.0.0 alongside a new `@SanitizeIgnore` opt-out.
+
 ## Extending the Framework
 
 ### Custom Sanitizer Implementation
@@ -219,7 +260,8 @@ public String processInput(String rawPhoneNumber) {
 sanitizer-lib/             ← Parent project (packaging=pom)
 ├── sanitizer-core/        ← Core API and standard implementations
 ├── sanitizer-spring/      ← Spring Boot integration components
-└── sanitizer-jpa/         ← JPA persistence integration
+├── sanitizer-jpa/         ← JPA persistence integration
+└── sanitizer-jpa-spring/  ← Spring Boot starter wiring Hibernate-aware safety checks into the JPA entity listener
 ```
 
 Each module maintains its own dependency set while inheriting common configuration from the parent build script.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 allprojects {
     group = "io.github.rabinarayanpatra.sanitizer"
-    version = "1.1.0"
+    version = "1.2.0"
 
     repositories {
         mavenCentral()

--- a/docs/index.html
+++ b/docs/index.html
@@ -205,7 +205,7 @@
 
   <header>
     <div class="topline">
-      <span>sanitizer-lib · v1.1.0</span>
+      <span>sanitizer-lib · v1.2.0</span>
       <div class="links">
         <a href="javadoc/">javadoc</a>
         <a href="https://github.com/rabinarayanpatra/sanitizer-lib">github</a>
@@ -232,16 +232,19 @@
 
     <div class="install-label">build.gradle.kts</div>
 <pre><span class="tok-c">// Spring Boot</span>
-implementation(<span class="tok-k">"io.github.rabinarayanpatra.sanitizer:sanitizer-spring:1.1.0"</span>)
+implementation(<span class="tok-k">"io.github.rabinarayanpatra.sanitizer:sanitizer-spring:1.2.0"</span>)
 
 <span class="tok-c">// JPA (optional)</span>
-implementation(<span class="tok-k">"io.github.rabinarayanpatra.sanitizer:sanitizer-jpa:1.1.0"</span>)</pre>
+implementation(<span class="tok-k">"io.github.rabinarayanpatra.sanitizer:sanitizer-jpa:1.2.0"</span>)
+
+<span class="tok-c">// JPA + Spring Boot starter (Hibernate-aware safety checks)</span>
+implementation(<span class="tok-k">"io.github.rabinarayanpatra.sanitizer:sanitizer-jpa-spring:1.2.0"</span>)</pre>
 
     <div class="install-label">pom.xml</div>
 <pre>&lt;dependency&gt;
   &lt;groupId&gt;io.github.rabinarayanpatra.sanitizer&lt;/groupId&gt;
   &lt;artifactId&gt;sanitizer-spring&lt;/artifactId&gt;
-  &lt;version&gt;1.1.0&lt;/version&gt;
+  &lt;version&gt;1.2.0&lt;/version&gt;
 &lt;/dependency&gt;</pre>
   </section>
 
@@ -281,7 +284,7 @@ public class Payment {
       <li><b>Composable.</b> Chain sanitizers in any order. Mix built-ins with your own.</li>
       <li><b>Framework-aware.</b> Hooks into Jackson for DTOs and JPA listeners for entities — no manual calls.</li>
       <li><b>Configurable.</b> Pass parameters via <code>params="maxLength=100,suffix=..."</code>.</li>
-      <li><b>Modular.</b> <code>sanitizer-core</code> stands alone. Add <code>-spring</code> or <code>-jpa</code> only if you need them.</li>
+      <li><b>Modular.</b> <code>sanitizer-core</code> stands alone. Add <code>-spring</code>, <code>-jpa</code>, or <code>-jpa-spring</code> only if you need them.</li>
     </ul>
   </section>
 
@@ -324,7 +327,7 @@ public class NumericOnlySanitizer implements FieldSanitizer&lt;String&gt; {
   <section id="docs">
     <h2>documentation</h2>
     <ul class="dash">
-      <li><a href="javadoc/">API Javadoc</a> — full reference for all three modules</li>
+      <li><a href="javadoc/">API Javadoc</a> — full reference for sanitizer-core, sanitizer-spring, sanitizer-jpa, sanitizer-jpa-spring</li>
       <li><a href="https://github.com/rabinarayanpatra/sanitizer-lib/blob/master/README.md">README</a> — extended guide and examples</li>
       <li><a href="https://github.com/rabinarayanpatra/sanitizer-lib/blob/master/CHANGELOG.md">Changelog</a></li>
       <li><a href="https://central.sonatype.com/namespace/io.github.rabinarayanpatra.sanitizer">Maven Central</a></li>

--- a/docs/superpowers/plans/2026-06-05-records-and-traversal-engine.md
+++ b/docs/superpowers/plans/2026-06-05-records-and-traversal-engine.md
@@ -1,0 +1,3834 @@
+# Records support and recursive traversal engine — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship v1.2.0 of `sanitizer-lib` with first-class Java records support and an opt-in recursive traversal engine that walks nested POJOs, records, collections, and maps — strictly backward compatible for all existing POJO callers.
+
+**Architecture:** A new package-private `core.traversal` engine (`TraversalEngine` + `ClassMetadata` + `FieldDescriptor` + `TraversalState`) replaces the inline reflection loop inside `SanitizationUtils`. The existing `SanitizationUtils` becomes a thin facade. A new public `TraversalSafetyChecker` interface lets callers (in particular a new Hibernate-aware impl) gate descent into lazy associations. Records are reconstructed via canonical constructor; POJOs continue to mutate in place. A new `sanitizer-jpa-spring` module wires the Hibernate checker via Spring's `SpringBeanContainer`.
+
+**Tech Stack:** Java 21, Gradle Kotlin DSL, JUnit 5 (Jupiter), Mockito (already on classpath via spring-boot-starter-test), JSpecify nullness annotations, ErrorProne, Spotless, Spring Boot 3.4.5 BOM, Hibernate ORM (via Spring Boot starter), SLF4J API.
+
+**Spec reference:** `docs/superpowers/specs/2026-06-05-records-and-traversal-engine-design.md`
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0.1: Confirm clean working tree on master**
+
+Run: `git -C /Volumes/Work/sanitizer-lib status`
+Expected: `On branch master`, `nothing to commit, working tree clean`. If dirty, stash before proceeding.
+
+- [ ] **Step 0.2: Create a feature branch**
+
+Run:
+```bash
+cd /Volumes/Work/sanitizer-lib
+git checkout -b feat/v1.2.0-records-and-traversal
+```
+Expected: `Switched to a new branch 'feat/v1.2.0-records-and-traversal'`.
+
+- [ ] **Step 0.3: Baseline build green**
+
+Run: `./gradlew check`
+Expected: `BUILD SUCCESSFUL`. If any test fails, stop and investigate before any code change.
+
+---
+
+## Phase 1: Annotation evolution + safety-checker interface
+
+### Task 1: Add `cascade` attribute and default `using={}` to `@Sanitize`
+
+**Files:**
+- Modify: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/annotation/Sanitize.java`
+- Test: `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/annotation/SanitizeAnnotationTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/annotation/SanitizeAnnotationTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.annotation;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SanitizeAnnotationTest {
+
+    @Test
+    void cascadeDefaultsToFalse() throws NoSuchFieldException {
+        final Field field = Fixtures.class.getDeclaredField("trimmedOnly");
+        final Sanitize ann = field.getAnnotation(Sanitize.class);
+        assertFalse(ann.cascade());
+    }
+
+    @Test
+    void cascadeReadsTrueWhenSet() throws NoSuchFieldException {
+        final Field field = Fixtures.class.getDeclaredField("cascadeOnly");
+        final Sanitize ann = field.getAnnotation(Sanitize.class);
+        assertTrue(ann.cascade());
+        assertArrayEquals(new Class<?>[0], ann.using());
+    }
+
+    @Test
+    void cascadeCombinedWithUsing() throws NoSuchFieldException {
+        final Field field = Fixtures.class.getDeclaredField("trimAndCascade");
+        final Sanitize ann = field.getAnnotation(Sanitize.class);
+        assertTrue(ann.cascade());
+        assertEquals(1, ann.using().length);
+        assertEquals(TrimSanitizer.class, ann.using()[0]);
+    }
+
+    static class Fixtures {
+        @Sanitize(using = TrimSanitizer.class)
+        String trimmedOnly;
+
+        @Sanitize(cascade = true)
+        Object cascadeOnly;
+
+        @Sanitize(using = TrimSanitizer.class, cascade = true)
+        String trimAndCascade;
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.annotation.SanitizeAnnotationTest"`
+Expected: COMPILATION FAILURE — `cannot find symbol: method cascade()` and the `@Sanitize(cascade = true)` form is invalid because `using` has no default yet.
+
+- [ ] **Step 3: Update the annotation**
+
+Replace `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/annotation/Sanitize.java` body with:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+
+/**
+ * Apply one or more {@link FieldSanitizer} implementations to this field, in the
+ * order listed, and/or descend into this field's object graph.
+ *
+ * <p>
+ * This annotation is {@link Repeatable}, so multiple {@code @Sanitize}
+ * annotations can be stacked on the same field. Sanitizers are applied in
+ * declaration order. When {@link #cascade()} is true on any stacked instance,
+ * the engine descends into the field's value after self-sanitizers run.
+ *
+ * @since 1.0.0
+ */
+@Repeatable(Sanitizes.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Sanitize {
+    /**
+     * The ordered list of FieldSanitizer implementations to apply to this field's
+     * value. May be empty when the annotation is used solely to opt into
+     * {@link #cascade() cascade}.
+     *
+     * @return the sanitizer classes, possibly empty
+     */
+    @SuppressWarnings("java:S1452")
+    Class<? extends FieldSanitizer<?>>[] using() default {};
+
+    /**
+     * Optional comma-separated {@code key=value} configuration parameters passed
+     * to {@link io.github.rabinarayanpatra.sanitizer.core.ConfigurableFieldSanitizer}
+     * implementations. Ignored for non-configurable sanitizers.
+     *
+     * <p>
+     * Example: {@code params = "maxLength=100,suffix=..."} or
+     * {@code params = "reveal=4"}
+     *
+     * @return the parameter string, empty by default
+     * @since 1.1.0
+     */
+    String params() default "";
+
+    /**
+     * When true, the traversal engine descends into this field's value after any
+     * self-sanitizers run. Supported on fields whose static type is a POJO,
+     * record, {@link java.util.Collection}, or {@link java.util.Map}. Applying
+     * {@code cascade=true} to a leaf type (e.g. {@code String}, primitive,
+     * boxed primitive, {@code UUID}, JSR-310 temporal, {@code BigDecimal},
+     * {@code BigInteger}, {@code Enum}) is rejected at metadata-build time.
+     *
+     * @return true to descend into this field's object graph
+     * @since 1.2.0
+     */
+    boolean cascade() default false;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.annotation.SanitizeAnnotationTest"`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Full module test pass**
+
+Run: `./gradlew :sanitizer-core:check`
+Expected: BUILD SUCCESSFUL. (Existing tests must still pass — the new `cascade()` attribute is purely additive.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/annotation/Sanitize.java \
+        sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/annotation/SanitizeAnnotationTest.java
+git commit -m "feat(core): add cascade attribute and default using={} to @Sanitize
+
+Assisted by AI"
+```
+
+---
+
+### Task 2: Add public `TraversalSafetyChecker` interface
+
+**Files:**
+- Create: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/TraversalSafetyChecker.java`
+- Test: `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/TraversalSafetyCheckerTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/TraversalSafetyCheckerTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TraversalSafetyCheckerTest {
+
+    @Test
+    void alwaysReturnsTrueForAnyParentAndField() throws NoSuchFieldException {
+        final Field field = Holder.class.getDeclaredField("name");
+        assertTrue(TraversalSafetyChecker.ALWAYS.shouldDescend(new Holder(), field));
+    }
+
+    @Test
+    void lambdaImplementationIsHonored() throws NoSuchFieldException {
+        final Field field = Holder.class.getDeclaredField("name");
+        final TraversalSafetyChecker neverDescend = (parent, f) -> false;
+        assertFalse(neverDescend.shouldDescend(new Holder(), field));
+    }
+
+    static class Holder {
+        String name;
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyCheckerTest"`
+Expected: COMPILATION FAILURE — `cannot find symbol: class TraversalSafetyChecker`.
+
+- [ ] **Step 3: Create the interface**
+
+Create `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/TraversalSafetyChecker.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core;
+
+import java.lang.reflect.Field;
+
+/**
+ * Pluggable gate that lets callers decide whether the traversal engine may
+ * descend into a given field of a parent object. Used to avoid touching
+ * non-initialized JPA lazy associations or other contexts where reading a
+ * field is expensive or unsafe.
+ *
+ * @since 1.2.0
+ */
+@FunctionalInterface
+public interface TraversalSafetyChecker {
+
+    /**
+     * Returns true when the engine may read and recurse into {@code field} on
+     * {@code parent}.
+     *
+     * @param parent
+     *            the bean currently being walked
+     * @param field
+     *            the field about to be descended into
+     * @return true to allow descent; false to skip this field
+     */
+    boolean shouldDescend(Object parent, Field field);
+
+    /**
+     * No-op checker that always permits descent. Default used by
+     * {@code sanitizer-core} when callers do not supply a custom checker.
+     */
+    TraversalSafetyChecker ALWAYS = (parent, field) -> true;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyCheckerTest"`
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/TraversalSafetyChecker.java \
+        sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/TraversalSafetyCheckerTest.java
+git commit -m "feat(core): add public TraversalSafetyChecker interface
+
+Assisted by AI"
+```
+
+---
+
+## Phase 2: Traversal internals (Kind, FieldDescriptor, ClassMetadata, TraversalState)
+
+### Task 3: Add `Kind` enum and `FieldDescriptor` (package-private)
+
+**Files:**
+- Create: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/Kind.java`
+- Create: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/FieldDescriptor.java`
+- Test: `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/FieldDescriptorTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/FieldDescriptorTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FieldDescriptorTest {
+
+    @Test
+    void pojoFieldDescriptorExposesFieldAndChain() throws NoSuchFieldException {
+        final Field f = Fixtures.class.getDeclaredField("name");
+        final List<FieldSanitizer<Object>> chain = List.of(new TrimSanitizer().asObjectSanitizer());
+        final FieldDescriptor d = FieldDescriptor.forPojoField(f, chain, false, Kind.LEAF, null);
+        assertSame(f, d.field());
+        assertNull(d.recordComponent());
+        assertEquals(chain, d.chain());
+        assertEquals(Kind.LEAF, d.kind());
+        assertNull(d.elementType());
+        assertTrue(!d.cascade());
+    }
+
+    static class Fixtures {
+        String name;
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.FieldDescriptorTest"`
+Expected: COMPILATION FAILURE — missing classes `FieldDescriptor`, `Kind`, and method `TrimSanitizer.asObjectSanitizer`.
+
+- [ ] **Step 3: Create `Kind` enum**
+
+Create `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/Kind.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+/**
+ * Classification of a field's declared type that drives traversal behavior.
+ */
+enum Kind {
+    /** Strings, primitives/boxed, UUID, JSR-310 temporals, BigDecimal/Integer, Enum. */
+    LEAF,
+    /** Plain mutable Java object (any class that is not LEAF/RECORD/COLLECTION/MAP). */
+    POJO,
+    /** Subclass of {@link java.lang.Record}. */
+    RECORD,
+    /** Subtype of {@link java.util.Collection}. */
+    COLLECTION,
+    /** Subtype of {@link java.util.Map}. */
+    MAP
+}
+```
+
+- [ ] **Step 4: Create `FieldDescriptor` record**
+
+Create `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/FieldDescriptor.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.RecordComponent;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+
+/**
+ * Compiled descriptor for a single field (POJO) or record component. Built once
+ * per class by {@link ClassMetadata} and reused on every traversal.
+ */
+record FieldDescriptor(
+        @Nullable Field field,
+        @Nullable RecordComponent recordComponent,
+        List<FieldSanitizer<Object>> chain,
+        boolean cascade,
+        Kind kind,
+        @Nullable Class<?> elementType) {
+
+    static FieldDescriptor forPojoField(
+            final Field field,
+            final List<FieldSanitizer<Object>> chain,
+            final boolean cascade,
+            final Kind kind,
+            final @Nullable Class<?> elementType) {
+        return new FieldDescriptor(field, null, chain, cascade, kind, elementType);
+    }
+
+    static FieldDescriptor forRecordComponent(
+            final RecordComponent component,
+            final List<FieldSanitizer<Object>> chain,
+            final boolean cascade,
+            final Kind kind,
+            final @Nullable Class<?> elementType) {
+        return new FieldDescriptor(null, component, chain, cascade, kind, elementType);
+    }
+}
+```
+
+- [ ] **Step 5: Add `asObjectSanitizer` helper on `FieldSanitizer` for safe casting in tests**
+
+This helper avoids `unchecked` casts in test code. Edit `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/FieldSanitizer.java` to add:
+
+Replace the entire file with:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Strategy interface for sanitizing a single field value.
+ *
+ * @param <T>
+ *            the type of the field (e.g., String, LocalDate, BigDecimal)
+ */
+@FunctionalInterface
+public interface FieldSanitizer<T> {
+    /**
+     * Apply sanitization to the input value.
+     *
+     * @param input
+     *            the raw value (maybe null)
+     * @return the sanitized value (maybe null)
+     */
+    @Nullable
+    T sanitize(@Nullable T input);
+
+    /**
+     * Returns this sanitizer typed as {@code FieldSanitizer<Object>}. The cast is
+     * safe at runtime because the traversal engine routes each sanitizer only to
+     * fields whose declared type matches the sanitizer's generic parameter; a
+     * {@code ClassCastException} thrown by {@code sanitize} is caught and rewrapped
+     * with a descriptive {@code IllegalStateException} by the engine.
+     *
+     * @return this sanitizer as an Object-typed sanitizer
+     * @since 1.2.0
+     */
+    @SuppressWarnings("unchecked")
+    default FieldSanitizer<Object> asObjectSanitizer() {
+        return (FieldSanitizer<Object>) this;
+    }
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.FieldDescriptorTest"`
+Expected: 1 test passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/Kind.java \
+        sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/FieldDescriptor.java \
+        sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/FieldSanitizer.java \
+        sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/FieldDescriptorTest.java
+git commit -m "feat(core): introduce Kind enum and FieldDescriptor for traversal
+
+Assisted by AI"
+```
+
+---
+
+### Task 4: Add `ClassMetadata` with `Kind` resolution and metadata build
+
+**Files:**
+- Create: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadata.java`
+- Test: `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadataTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadataTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClassMetadataTest {
+
+    @Test
+    void leafTypesResolveToLeafKind() {
+        final ClassMetadata meta = ClassMetadata.of(LeafBean.class);
+        final Map<String, FieldDescriptor> byName = byFieldName(meta);
+        assertEquals(Kind.LEAF, byName.get("text").kind());
+        assertEquals(Kind.LEAF, byName.get("count").kind());
+        assertEquals(Kind.LEAF, byName.get("boxed").kind());
+        assertEquals(Kind.LEAF, byName.get("uuid").kind());
+        assertEquals(Kind.LEAF, byName.get("instant").kind());
+        assertEquals(Kind.LEAF, byName.get("amount").kind());
+        assertEquals(Kind.LEAF, byName.get("color").kind());
+    }
+
+    @Test
+    void recordIsDetectedAndCanonicalCtorCaptured() {
+        final ClassMetadata meta = ClassMetadata.of(SimpleRecord.class);
+        assertTrue(meta.isRecord());
+        assertNotNull(meta.canonicalCtor());
+        assertNotNull(meta.components());
+        assertEquals(1, meta.components().length);
+        assertEquals(1, meta.fields().size());
+        assertEquals(Kind.LEAF, meta.fields().get(0).kind());
+    }
+
+    @Test
+    void collectionFieldResolvesElementType() {
+        final ClassMetadata meta = ClassMetadata.of(CollectionBean.class);
+        final Map<String, FieldDescriptor> byName = byFieldName(meta);
+        assertEquals(Kind.COLLECTION, byName.get("names").kind());
+        assertSame(String.class, byName.get("names").elementType());
+        assertEquals(Kind.COLLECTION, byName.get("records").kind());
+        assertSame(SimpleRecord.class, byName.get("records").elementType());
+        assertEquals(Kind.MAP, byName.get("byName").kind());
+        assertSame(SimpleRecord.class, byName.get("byName").elementType());
+    }
+
+    @Test
+    void pojoFieldIsClassifiedAsPojo() {
+        final ClassMetadata meta = ClassMetadata.of(NestedBean.class);
+        final Map<String, FieldDescriptor> byName = byFieldName(meta);
+        assertEquals(Kind.POJO, byName.get("child").kind());
+    }
+
+    @Test
+    void cascadeTrueOnLeafFieldThrows() {
+        final IllegalStateException ex = assertThrows(
+                IllegalStateException.class, () -> ClassMetadata.of(IllegalLeafCascade.class));
+        assertTrue(ex.getMessage().contains("cascade"));
+        assertTrue(ex.getMessage().contains("text"));
+        assertTrue(ex.getMessage().contains("LEAF"));
+    }
+
+    @Test
+    void superclassFieldsWalked() {
+        final ClassMetadata meta = ClassMetadata.of(ChildAnnotated.class);
+        final Map<String, FieldDescriptor> byName = byFieldName(meta);
+        assertNotNull(byName.get("parentName"));
+        assertNotNull(byName.get("childName"));
+    }
+
+    @Test
+    void fieldWithoutSanitizeAnnotationIsSkipped() {
+        final ClassMetadata meta = ClassMetadata.of(PartiallyAnnotated.class);
+        assertEquals(1, meta.fields().size());
+        assertEquals("annotated", meta.fields().get(0).field().getName());
+    }
+
+    @Test
+    void emptyUsingArrayWithCascadeFalseIsRejected() {
+        final IllegalStateException ex = assertThrows(
+                IllegalStateException.class, () -> ClassMetadata.of(NoOpAnnotation.class));
+        assertTrue(ex.getMessage().contains("no sanitizer and cascade=false"));
+    }
+
+    @Test
+    void rawCollectionTypeReturnsNullElementType() {
+        final ClassMetadata meta = ClassMetadata.of(RawCollectionBean.class);
+        final FieldDescriptor d = meta.fields().get(0);
+        assertEquals(Kind.COLLECTION, d.kind());
+        assertNull(d.elementType());
+    }
+
+    private static Map<String, FieldDescriptor> byFieldName(final ClassMetadata meta) {
+        final java.util.Map<String, FieldDescriptor> m = new java.util.LinkedHashMap<>();
+        for (final FieldDescriptor d : meta.fields()) {
+            m.put(d.field() != null ? d.field().getName() : d.recordComponent().getName(), d);
+        }
+        return m;
+    }
+
+    enum Color { RED, BLUE }
+
+    static class LeafBean {
+        @Sanitize(using = TrimSanitizer.class) String text;
+        @Sanitize(using = TrimSanitizer.class) int count;
+        @Sanitize(using = TrimSanitizer.class) Integer boxed;
+        @Sanitize(using = TrimSanitizer.class) UUID uuid;
+        @Sanitize(using = TrimSanitizer.class) Instant instant;
+        @Sanitize(using = TrimSanitizer.class) BigDecimal amount;
+        @Sanitize(using = TrimSanitizer.class) Color color;
+    }
+
+    record SimpleRecord(@Sanitize(using = TrimSanitizer.class) String value) {}
+
+    static class CollectionBean {
+        @Sanitize(using = LowerCaseSanitizer.class) List<String> names;
+        @Sanitize(cascade = true) Set<SimpleRecord> records;
+        @Sanitize(cascade = true) Map<String, SimpleRecord> byName;
+    }
+
+    static class NestedBean {
+        @Sanitize(cascade = true) LeafBean child;
+    }
+
+    static class IllegalLeafCascade {
+        @Sanitize(cascade = true) String text;
+    }
+
+    static class ParentAnnotated {
+        @Sanitize(using = TrimSanitizer.class) String parentName;
+    }
+
+    static class ChildAnnotated extends ParentAnnotated {
+        @Sanitize(using = UpperCaseSanitizer.class) String childName;
+    }
+
+    static class PartiallyAnnotated {
+        String unannotated;
+        @Sanitize(using = TrimSanitizer.class) String annotated;
+    }
+
+    static class NoOpAnnotation {
+        @Sanitize String pointless;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    static class RawCollectionBean {
+        @Sanitize(cascade = true) List raw;
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.ClassMetadataTest"`
+Expected: COMPILATION FAILURE — `cannot find symbol: class ClassMetadata`.
+
+- [ ] **Step 3: Create `ClassMetadata`**
+
+Create `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadata.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.RecordComponent;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jspecify.annotations.Nullable;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.core.ConfigurableFieldSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizerInstantiationException;
+
+/**
+ * Per-class compiled plan: ordered list of {@link FieldDescriptor} plus record
+ * metadata when applicable. Constructed once per class and cached in a static
+ * {@code ConcurrentHashMap}.
+ */
+final class ClassMetadata {
+
+    private static final Map<Class<?>, ClassMetadata> CACHE = new ConcurrentHashMap<>();
+
+    private static final Set<Class<?>> LEAF_TYPES = Set.of(
+            String.class,
+            Boolean.class, Byte.class, Character.class, Short.class,
+            Integer.class, Long.class, Float.class, Double.class,
+            UUID.class,
+            LocalDate.class, LocalDateTime.class, Instant.class,
+            BigDecimal.class, BigInteger.class);
+
+    private final Class<?> type;
+    private final boolean isRecord;
+    private final @Nullable Constructor<?> canonicalCtor;
+    private final RecordComponent @Nullable [] components;
+    private final List<FieldDescriptor> fields;
+
+    private ClassMetadata(
+            final Class<?> type,
+            final boolean isRecord,
+            final @Nullable Constructor<?> canonicalCtor,
+            final RecordComponent @Nullable [] components,
+            final List<FieldDescriptor> fields) {
+        this.type = type;
+        this.isRecord = isRecord;
+        this.canonicalCtor = canonicalCtor;
+        this.components = components;
+        this.fields = List.copyOf(fields);
+    }
+
+    static ClassMetadata of(final Class<?> cls) {
+        return CACHE.computeIfAbsent(cls, ClassMetadata::build);
+    }
+
+    Class<?> type() { return type; }
+    boolean isRecord() { return isRecord; }
+    @Nullable Constructor<?> canonicalCtor() { return canonicalCtor; }
+    RecordComponent @Nullable [] components() { return components; }
+    List<FieldDescriptor> fields() { return fields; }
+
+    private static ClassMetadata build(final Class<?> cls) {
+        if (cls.isRecord()) {
+            return buildRecord(cls);
+        }
+        return buildPojo(cls);
+    }
+
+    private static ClassMetadata buildRecord(final Class<?> cls) {
+        final RecordComponent[] components = cls.getRecordComponents();
+        final Class<?>[] paramTypes = new Class<?>[components.length];
+        for (int i = 0; i < components.length; i++) {
+            paramTypes[i] = components[i].getType();
+        }
+        final Constructor<?> canonical;
+        try {
+            canonical = cls.getDeclaredConstructor(paramTypes);
+            canonical.setAccessible(true);
+        } catch (final NoSuchMethodException e) {
+            throw new SanitizerInstantiationException(
+                    "Cannot find canonical constructor for record " + cls.getName(), e);
+        }
+        final List<FieldDescriptor> descriptors = new ArrayList<>(components.length);
+        for (final RecordComponent rc : components) {
+            descriptors.add(describeRecordComponent(cls, rc));
+        }
+        return new ClassMetadata(cls, true, canonical, components, descriptors);
+    }
+
+    private static FieldDescriptor describeRecordComponent(final Class<?> owner, final RecordComponent rc) {
+        final Sanitize[] anns = rc.getAnnotationsByType(Sanitize.class);
+        final List<FieldSanitizer<Object>> chain = buildChain(anns);
+        final boolean cascade = anyCascade(anns);
+        validateMeaningful(owner, rc.getName(), chain, cascade);
+        final Class<?> declared = rc.getType();
+        final Kind kind = resolveKind(declared);
+        validateCascadeKind(owner, rc.getName(), kind, cascade);
+        final Class<?> elementType = resolveElementType(rc.getGenericType(), kind);
+        return FieldDescriptor.forRecordComponent(rc, chain, cascade, kind, elementType);
+    }
+
+    private static ClassMetadata buildPojo(final Class<?> cls) {
+        final List<FieldDescriptor> descriptors = new ArrayList<>();
+        Class<?> current = cls;
+        while (current != null && current != Object.class) {
+            for (final Field field : current.getDeclaredFields()) {
+                final Sanitize[] anns = field.getAnnotationsByType(Sanitize.class);
+                if (anns.length == 0) {
+                    continue;
+                }
+                field.setAccessible(true);
+                final List<FieldSanitizer<Object>> chain = buildChain(anns);
+                final boolean cascade = anyCascade(anns);
+                validateMeaningful(cls, field.getName(), chain, cascade);
+                final Kind kind = resolveKind(field.getType());
+                validateCascadeKind(cls, field.getName(), kind, cascade);
+                final Class<?> elementType = resolveElementType(field.getGenericType(), kind);
+                descriptors.add(FieldDescriptor.forPojoField(field, chain, cascade, kind, elementType));
+            }
+            current = current.getSuperclass();
+        }
+        return new ClassMetadata(cls, false, null, null, descriptors);
+    }
+
+    private static List<FieldSanitizer<Object>> buildChain(final Sanitize[] anns) {
+        final List<FieldSanitizer<Object>> chain = new ArrayList<>();
+        for (final Sanitize ann : anns) {
+            for (final Class<? extends FieldSanitizer<?>> sanitizerClass : ann.using()) {
+                final FieldSanitizer<?> sanitizer;
+                try {
+                    sanitizer = sanitizerClass.getDeclaredConstructor().newInstance();
+                } catch (final ReflectiveOperationException e) {
+                    throw new SanitizerInstantiationException(
+                            "Cannot instantiate sanitizer " + sanitizerClass.getName(), e);
+                }
+                if (sanitizer instanceof ConfigurableFieldSanitizer<?> configurable && !ann.params().isBlank()) {
+                    configurable.configure(ConfigurableFieldSanitizer.parseParams(ann.params()));
+                }
+                chain.add(sanitizer.asObjectSanitizer());
+            }
+        }
+        return chain;
+    }
+
+    private static boolean anyCascade(final Sanitize[] anns) {
+        for (final Sanitize ann : anns) {
+            if (ann.cascade()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void validateMeaningful(
+            final Class<?> owner, final String name, final List<FieldSanitizer<Object>> chain, final boolean cascade) {
+        if (chain.isEmpty() && !cascade) {
+            throw new IllegalStateException(
+                    "@Sanitize on " + owner.getName() + "." + name
+                            + " has no sanitizer and cascade=false. Either supply using={...} or set cascade=true.");
+        }
+    }
+
+    private static void validateCascadeKind(
+            final Class<?> owner, final String name, final Kind kind, final boolean cascade) {
+        if (cascade && kind == Kind.LEAF) {
+            throw new IllegalStateException(
+                    "@Sanitize(cascade=true) on " + owner.getName() + "." + name
+                            + " resolves to a LEAF type. Cascade requires POJO, RECORD, COLLECTION, or MAP.");
+        }
+    }
+
+    private static Kind resolveKind(final Class<?> declared) {
+        if (declared.isPrimitive() || LEAF_TYPES.contains(declared) || declared.isEnum()) {
+            return Kind.LEAF;
+        }
+        if (declared.isRecord()) {
+            return Kind.RECORD;
+        }
+        if (Collection.class.isAssignableFrom(declared)) {
+            return Kind.COLLECTION;
+        }
+        if (Map.class.isAssignableFrom(declared)) {
+            return Kind.MAP;
+        }
+        return Kind.POJO;
+    }
+
+    private static @Nullable Class<?> resolveElementType(final Type genericType, final Kind kind) {
+        if (kind != Kind.COLLECTION && kind != Kind.MAP) {
+            return null;
+        }
+        if (!(genericType instanceof ParameterizedType pt)) {
+            return null;
+        }
+        final Type[] args = pt.getActualTypeArguments();
+        if (args.length == 0) {
+            return null;
+        }
+        final Type target = (kind == Kind.MAP && args.length > 1) ? args[1] : args[0];
+        if (target instanceof Class<?> cls) {
+            return cls;
+        }
+        if (target instanceof ParameterizedType nested && nested.getRawType() instanceof Class<?> raw) {
+            return raw;
+        }
+        return null;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.ClassMetadataTest"`
+Expected: all 9 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadata.java \
+        sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadataTest.java
+git commit -m "feat(core): add ClassMetadata with Kind resolution and validation
+
+Assisted by AI"
+```
+
+---
+
+### Task 5: Add `TraversalState` carrier
+
+**Files:**
+- Create: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalState.java`
+- Test: `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalStateTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalStateTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TraversalStateTest {
+
+    @Test
+    void markVisitedReturnsTrueOnFirstVisitAndFalseOnRevisit() {
+        final TraversalState state = new TraversalState();
+        final Object node = new Object();
+        assertTrue(state.markVisited(node));
+        assertFalse(state.markVisited(node));
+    }
+
+    @Test
+    void recordsAreStoredAndRetrievedByIdentity() {
+        final TraversalState state = new TraversalState();
+        final String original = "a";
+        final String rebuilt = "A";
+        assertNull(state.findReconstructed(original));
+        state.storeReconstructed(original, rebuilt);
+        assertSame(rebuilt, state.findReconstructed(original));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalStateTest"`
+Expected: COMPILATION FAILURE — `cannot find symbol: class TraversalState`.
+
+- [ ] **Step 3: Create `TraversalState`**
+
+Create `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalState.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.util.IdentityHashMap;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Mutable per-invocation traversal state. Tracks visited POJOs/collections/maps
+ * for cycle detection and reconstructed record instances keyed by their
+ * original references.
+ */
+final class TraversalState {
+
+    private final IdentityHashMap<Object, Boolean> visited = new IdentityHashMap<>();
+    private final IdentityHashMap<Object, Object> reconstructedRecords = new IdentityHashMap<>();
+
+    /**
+     * @return true the first time this node is visited; false on every subsequent
+     *         visit (indicates a cycle).
+     */
+    boolean markVisited(final Object node) {
+        return visited.put(node, Boolean.TRUE) == null;
+    }
+
+    void storeReconstructed(final Object original, final Object rebuilt) {
+        reconstructedRecords.put(original, rebuilt);
+    }
+
+    @Nullable Object findReconstructed(final Object original) {
+        return reconstructedRecords.get(original);
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalStateTest"`
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalState.java \
+        sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalStateTest.java
+git commit -m "feat(core): add TraversalState for cycle detection and record dedup
+
+Assisted by AI"
+```
+
+---
+
+## Phase 3: TraversalEngine — incremental TDD
+
+### Task 6: Add SLF4J API dependency to sanitizer-core
+
+**Files:**
+- Modify: `sanitizer-core/build.gradle.kts`
+
+- [ ] **Step 1: Inspect current deps**
+
+Run: `cat /Volumes/Work/sanitizer-lib/sanitizer-core/build.gradle.kts`
+Expected output:
+```
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+```
+
+- [ ] **Step 2: Add SLF4J API**
+
+Replace contents of `sanitizer-core/build.gradle.kts` with:
+
+```kotlin
+dependencies {
+    api("org.slf4j:slf4j-api")
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.slf4j:slf4j-simple")
+}
+```
+
+The Spring Boot BOM applied at the root project pins both `slf4j-api` and `slf4j-simple`, so no explicit version is needed.
+
+- [ ] **Step 3: Verify deps resolve**
+
+Run: `./gradlew :sanitizer-core:dependencies --configuration runtimeClasspath | grep slf4j`
+Expected: shows `org.slf4j:slf4j-api:` resolved to a non-empty version.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sanitizer-core/build.gradle.kts
+git commit -m "build(core): add slf4j-api for traversal engine logging
+
+Assisted by AI"
+```
+
+---
+
+### Task 7: Create `TraversalEngine` skeleton — POJO baseline (no cascade, no records)
+
+This replicates the **current** `SanitizationUtils.apply` semantics for POJOs inside the new engine. Records still go through legacy throw path. No new behavior yet.
+
+**Files:**
+- Create: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java`
+- Test: `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEnginePojoBaselineTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEnginePojoBaselineTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class TraversalEnginePojoBaselineTest {
+
+    @Test
+    void walkSanitizesPojoFieldAndReturnsSameRef() {
+        final Bean b = new Bean();
+        b.name = "  HELLO  ";
+        final Object result = TraversalEngine.walk(b, new TraversalState(), TraversalSafetyChecker.ALWAYS);
+        assertSame(b, result);
+        assertEquals("hello", b.name);
+    }
+
+    @Test
+    void walkNullReturnsNull() {
+        assertNull(TraversalEngine.walk(null, new TraversalState(), TraversalSafetyChecker.ALWAYS));
+    }
+
+    @Test
+    void walkPojoWithNullFieldKeepsNull() {
+        final Bean b = new Bean();
+        b.name = null;
+        TraversalEngine.walk(b, new TraversalState(), TraversalSafetyChecker.ALWAYS);
+        assertNull(b.name);
+    }
+
+    static class Bean {
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+        String name;
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEnginePojoBaselineTest"`
+Expected: COMPILATION FAILURE — `cannot find symbol: class TraversalEngine`.
+
+- [ ] **Step 3: Create `TraversalEngine` baseline**
+
+Create `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.lang.reflect.Field;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+/**
+ * Recursive walker that applies sanitizers and (optionally) descends into a
+ * bean's object graph. Entry point: {@link #walk(Object, TraversalState, TraversalSafetyChecker)}.
+ */
+public final class TraversalEngine {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TraversalEngine.class);
+
+    private TraversalEngine() {
+    }
+
+    public static @Nullable Object walk(
+            final @Nullable Object node,
+            final TraversalState state,
+            final TraversalSafetyChecker checker) {
+        if (node == null) {
+            return null;
+        }
+        final ClassMetadata meta = ClassMetadata.of(node.getClass());
+        if (meta.isRecord()) {
+            throw new UnsupportedOperationException(
+                    "Records reached TraversalEngine but record support is not yet wired up: "
+                            + node.getClass().getName());
+        }
+        if (!state.markVisited(node)) {
+            return node;
+        }
+        walkPojo(node, meta);
+        return node;
+    }
+
+    private static void walkPojo(final Object node, final ClassMetadata meta) {
+        LOG.debug("walk class={} descriptors={}", node.getClass().getName(), meta.fields().size());
+        for (final FieldDescriptor d : meta.fields()) {
+            final Field field = d.field();
+            if (field == null) {
+                continue;
+            }
+            try {
+                final Object raw = field.get(node);
+                final Object sanitized = applyChain(raw, d.chain());
+                writeBackIfChanged(node, field, raw, sanitized);
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(
+                        "Cannot access field '" + field.getName() + "' on " + node.getClass().getName()
+                                + ". Ensure the field is mutable and accessible.",
+                        e);
+            } catch (final ClassCastException e) {
+                throw new IllegalStateException(
+                        "Type mismatch: sanitizer chain incompatible with field '" + field.getName()
+                                + "' of type " + field.getType().getName() + " on " + node.getClass().getName()
+                                + ". Ensure the sanitizer's generic type matches the field type.",
+                        e);
+            }
+        }
+    }
+
+    private static @Nullable Object applyChain(
+            final @Nullable Object raw,
+            final java.util.List<FieldSanitizer<Object>> chain) {
+        Object current = raw;
+        for (final FieldSanitizer<Object> s : chain) {
+            current = s.sanitize(current);
+        }
+        return current;
+    }
+
+    private static void writeBackIfChanged(
+            final Object node, final Field field, final @Nullable Object raw, final @Nullable Object sanitized)
+            throws IllegalAccessException {
+        if (raw == null && sanitized == null) {
+            return;
+        }
+        field.set(node, sanitized);
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEnginePojoBaselineTest"`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java \
+        sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEnginePojoBaselineTest.java
+git commit -m "feat(core): add TraversalEngine POJO baseline walker
+
+Assisted by AI"
+```
+
+---
+
+### Task 8: Wire `SanitizationUtils.apply` through `TraversalEngine` (POJO path only)
+
+Refactor `SanitizationUtils.apply(Object)` to delegate to the engine. Behavior for POJOs must be bit-identical. The legacy in-class CACHE is removed since `ClassMetadata.of` owns the cache.
+
+**Files:**
+- Modify: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtils.java`
+
+- [ ] **Step 1: Re-read existing tests to confirm contracts**
+
+Run: `./gradlew :sanitizer-core:test`
+Expected: all current tests PASS (sanity check before refactor).
+
+- [ ] **Step 2: Refactor `SanitizationUtils`**
+
+Replace contents of `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtils.java` with:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core;
+
+import org.jspecify.annotations.Nullable;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngine;
+import io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalState;
+
+/**
+ * Public facade for applying {@link Sanitize} annotations to bean fields. All
+ * traversal logic lives in
+ * {@link io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngine};
+ * this class is a thin entry point.
+ *
+ * @since 1.0.0
+ */
+public final class SanitizationUtils {
+
+    private SanitizationUtils() {
+    }
+
+    /**
+     * Applies sanitizers in place to a POJO. Throws for record inputs because
+     * record components cannot be mutated and the void return would discard the
+     * reconstructed instance. Use {@link #applyAndReturn(Object)} for records.
+     *
+     * @param bean
+     *            the POJO whose fields should be sanitized; may be null
+     * @throws IllegalArgumentException
+     *             when {@code bean} is a {@link Record} instance
+     */
+    public static void apply(final @Nullable Object bean) {
+        if (bean == null) {
+            return;
+        }
+        if (bean.getClass().isRecord()) {
+            throw new IllegalArgumentException(
+                    "apply(Object) discards return value but record requires reassignment. "
+                            + "Use applyAndReturn(T) for record type " + bean.getClass().getName() + ".");
+        }
+        TraversalEngine.walk(bean, new TraversalState(), TraversalSafetyChecker.ALWAYS);
+    }
+}
+```
+
+- [ ] **Step 3: Update the existing `apply_throwsOnRecord` test to expect `IllegalArgumentException`**
+
+Edit `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtilsTest.java`. Find the `apply_throwsOnRecord` method (lines 44-50) and replace it with:
+
+```java
+@Test
+void apply_throwsIllegalArgumentOnRecord() {
+    final ImmutableRecord rec = new ImmutableRecord("  HELLO  ");
+    final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> SanitizationUtils.apply(rec));
+    assertTrue(ex.getMessage().contains("ImmutableRecord"));
+    assertTrue(ex.getMessage().contains("applyAndReturn"));
+}
+```
+
+- [ ] **Step 4: Run all sanitizer-core tests**
+
+Run: `./gradlew :sanitizer-core:check`
+Expected: BUILD SUCCESSFUL. All existing tests pass (including the updated `apply_throwsIllegalArgumentOnRecord`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtils.java \
+        sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtilsTest.java
+git commit -m "refactor(core): route SanitizationUtils.apply through TraversalEngine
+
+Switches the exception thrown on record root inputs from
+UnsupportedOperationException to IllegalArgumentException and recommends
+applyAndReturn(T). Behavior on POJO inputs is bit-identical.
+
+Assisted by AI"
+```
+
+---
+
+### Task 9: Add `applyAndReturn(T)` facade methods and record reconstruction
+
+**Files:**
+- Modify: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtils.java`
+- Modify: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java`
+- Test: `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineRecordTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineRecordTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TraversalEngineRecordTest {
+
+    @Test
+    void recordRootIsReconstructedWithSanitizedComponent() {
+        final Simple input = new Simple("  HELLO  ");
+        final Simple out = SanitizationUtils.applyAndReturn(input);
+        assertNotSame(input, out);
+        assertEquals("hello", out.value());
+    }
+
+    @Test
+    void recordComponentWithoutAnnotationPassesThrough() {
+        final Mixed input = new Mixed("  HELLO  ", 42);
+        final Mixed out = SanitizationUtils.applyAndReturn(input);
+        assertEquals("hello", out.value());
+        assertEquals(42, out.count());
+    }
+
+    @Test
+    void recordWithNullComponentReconstructed() {
+        final Simple input = new Simple(null);
+        final Simple out = SanitizationUtils.applyAndReturn(input);
+        assertNotSame(input, out);
+        assertNull(out.value());
+    }
+
+    @Test
+    void applyAndReturnNullReturnsNull() {
+        assertNull(SanitizationUtils.applyAndReturn(null));
+    }
+
+    @Test
+    void applyAndReturnPojoReturnsSameRef() {
+        final PojoBean b = new PojoBean();
+        b.name = "  HELLO  ";
+        final PojoBean out = SanitizationUtils.applyAndReturn(b);
+        assertEquals(System.identityHashCode(b), System.identityHashCode(out));
+        assertEquals("hello", out.name);
+    }
+
+    @Test
+    void compactConstructorValidationPropagatesAsCause() {
+        final Validated input = new Validated("  HELLO  ");
+        // First reconstruction with non-empty raw passes; trigger failure via
+        // sanitizer producing blank → compact ctor throws.
+        final RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> SanitizationUtils.applyAndReturn(new Validated("   ")));
+        assertTrue(ex.getCause() instanceof IllegalArgumentException
+                || ex instanceof IllegalArgumentException
+                || ex.getMessage().contains("must not be blank"));
+        // input keeps original content (immutable)
+        assertEquals("  HELLO  ", input.value());
+    }
+
+    record Simple(@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) String value) {}
+
+    record Mixed(@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) String value, int count) {}
+
+    record Validated(@Sanitize(using = TrimSanitizer.class) String value) {
+        public Validated {
+            if (value == null || value.isBlank()) {
+                throw new IllegalArgumentException("value must not be blank");
+            }
+        }
+    }
+
+    static class PojoBean {
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+        String name;
+    }
+
+    // Unused but kept to ensure UpperCaseSanitizer import compiles in case future
+    // edits add fixtures using it.
+    @SuppressWarnings("unused")
+    private static final Class<?> KEEP_IMPORT = UpperCaseSanitizer.class;
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngineRecordTest"`
+Expected: COMPILATION FAILURE on `SanitizationUtils.applyAndReturn` and runtime `UnsupportedOperationException` from engine.
+
+- [ ] **Step 3: Add `walkRecord` to `TraversalEngine`**
+
+Replace contents of `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java` with:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.RecordComponent;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizerInstantiationException;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+/**
+ * Recursive walker that applies sanitizers and (optionally) descends into a
+ * bean's object graph. Entry point: {@link #walk(Object, TraversalState, TraversalSafetyChecker)}.
+ */
+public final class TraversalEngine {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TraversalEngine.class);
+
+    private TraversalEngine() {
+    }
+
+    public static @Nullable Object walk(
+            final @Nullable Object node,
+            final TraversalState state,
+            final TraversalSafetyChecker checker) {
+        if (node == null) {
+            return null;
+        }
+        final ClassMetadata meta = ClassMetadata.of(node.getClass());
+        if (meta.isRecord()) {
+            final Object cached = state.findReconstructed(node);
+            if (cached != null) {
+                return cached;
+            }
+            final Object built = walkRecord(node, meta);
+            state.storeReconstructed(node, built);
+            return built;
+        }
+        if (!state.markVisited(node)) {
+            return node;
+        }
+        walkPojo(node, meta);
+        return node;
+    }
+
+    private static Object walkRecord(final Object node, final ClassMetadata meta) {
+        LOG.debug("walk record class={} components={}", node.getClass().getName(), meta.fields().size());
+        final RecordComponent[] components = meta.components();
+        final Object[] args = new Object[components.length];
+        for (int i = 0; i < components.length; i++) {
+            final RecordComponent rc = components[i];
+            final FieldDescriptor d = meta.fields().get(i);
+            try {
+                final Object raw = rc.getAccessor().invoke(node);
+                args[i] = applyChain(raw, d.chain());
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(
+                        "Cannot invoke accessor for component '" + rc.getName() + "' on " + node.getClass().getName(),
+                        e);
+            } catch (final InvocationTargetException e) {
+                final Throwable cause = e.getCause() != null ? e.getCause() : e;
+                if (cause instanceof RuntimeException re) {
+                    throw re;
+                }
+                throw new IllegalStateException("Record accessor threw", cause);
+            } catch (final ClassCastException e) {
+                throw new IllegalStateException(
+                        "Type mismatch: sanitizer chain incompatible with record component '"
+                                + rc.getName() + "' of type " + rc.getType().getName()
+                                + " on " + node.getClass().getName(),
+                        e);
+            }
+        }
+        try {
+            return meta.canonicalCtor().newInstance(args);
+        } catch (final InvocationTargetException e) {
+            final Throwable cause = e.getCause() != null ? e.getCause() : e;
+            if (cause instanceof RuntimeException re) {
+                throw re;
+            }
+            throw new IllegalStateException("Record canonical constructor threw checked exception", cause);
+        } catch (final ReflectiveOperationException e) {
+            throw new SanitizerInstantiationException(
+                    "Cannot reconstruct record " + node.getClass().getName(), e);
+        }
+    }
+
+    private static void walkPojo(final Object node, final ClassMetadata meta) {
+        LOG.debug("walk pojo class={} fields={}", node.getClass().getName(), meta.fields().size());
+        for (final FieldDescriptor d : meta.fields()) {
+            final Field field = d.field();
+            if (field == null) {
+                continue;
+            }
+            try {
+                final Object raw = field.get(node);
+                final Object sanitized = applyChain(raw, d.chain());
+                writeBackIfChanged(node, field, raw, sanitized);
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(
+                        "Cannot access field '" + field.getName() + "' on " + node.getClass().getName()
+                                + ". Ensure the field is mutable and accessible.",
+                        e);
+            } catch (final ClassCastException e) {
+                throw new IllegalStateException(
+                        "Type mismatch: sanitizer chain incompatible with field '" + field.getName()
+                                + "' of type " + field.getType().getName() + " on " + node.getClass().getName()
+                                + ". Ensure the sanitizer's generic type matches the field type.",
+                        e);
+            }
+        }
+    }
+
+    private static @Nullable Object applyChain(final @Nullable Object raw, final List<FieldSanitizer<Object>> chain) {
+        Object current = raw;
+        for (final FieldSanitizer<Object> s : chain) {
+            current = s.sanitize(current);
+        }
+        return current;
+    }
+
+    private static void writeBackIfChanged(
+            final Object node, final Field field, final @Nullable Object raw, final @Nullable Object sanitized)
+            throws IllegalAccessException {
+        if (raw == null && sanitized == null) {
+            return;
+        }
+        field.set(node, sanitized);
+    }
+}
+```
+
+- [ ] **Step 4: Add `applyAndReturn` overloads to `SanitizationUtils`**
+
+Replace contents of `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtils.java` with:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core;
+
+import org.jspecify.annotations.Nullable;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngine;
+import io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalState;
+
+/**
+ * Public facade for applying {@link Sanitize} annotations to bean fields.
+ *
+ * @since 1.0.0
+ */
+public final class SanitizationUtils {
+
+    private SanitizationUtils() {
+    }
+
+    /**
+     * Applies sanitizers in place to a POJO. Throws for record inputs because
+     * record components cannot be mutated and the void return would discard the
+     * reconstructed instance. Use {@link #applyAndReturn(Object)} for records.
+     *
+     * @param bean
+     *            the POJO whose fields should be sanitized; may be null
+     * @throws IllegalArgumentException
+     *             when {@code bean} is a {@link Record} instance
+     */
+    public static void apply(final @Nullable Object bean) {
+        if (bean == null) {
+            return;
+        }
+        if (bean.getClass().isRecord()) {
+            throw new IllegalArgumentException(
+                    "apply(Object) discards return value but record requires reassignment. "
+                            + "Use applyAndReturn(T) for record type " + bean.getClass().getName() + ".");
+        }
+        TraversalEngine.walk(bean, new TraversalState(), TraversalSafetyChecker.ALWAYS);
+    }
+
+    /**
+     * Universal sanitization entry point. POJO inputs are mutated in place and
+     * the same reference is returned; record inputs are reconstructed via their
+     * canonical constructor and a new instance is returned.
+     *
+     * @param bean
+     *            the bean to sanitize; may be null
+     * @param <T>
+     *            the static type of the bean
+     * @return the sanitized bean (same ref for POJOs, new instance for records)
+     * @since 1.2.0
+     */
+    public static <T> @Nullable T applyAndReturn(final @Nullable T bean) {
+        return applyAndReturn(bean, TraversalSafetyChecker.ALWAYS);
+    }
+
+    /**
+     * Universal sanitization entry point with a custom safety checker. See
+     * {@link #applyAndReturn(Object)}.
+     *
+     * @param bean
+     *            the bean to sanitize; may be null
+     * @param checker
+     *            the safety checker that gates descent into individual fields;
+     *            must not be null
+     * @param <T>
+     *            the static type of the bean
+     * @return the sanitized bean (same ref for POJOs, new instance for records)
+     * @since 1.2.0
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> @Nullable T applyAndReturn(
+            final @Nullable T bean, final TraversalSafetyChecker checker) {
+        if (bean == null) {
+            return null;
+        }
+        return (T) TraversalEngine.walk(bean, new TraversalState(), checker);
+    }
+}
+```
+
+- [ ] **Step 5: Run the new test**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngineRecordTest"`
+Expected: 6 tests pass.
+
+- [ ] **Step 6: Run all sanitizer-core tests**
+
+Run: `./gradlew :sanitizer-core:check`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java \
+        sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtils.java \
+        sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineRecordTest.java
+git commit -m "feat(core): add applyAndReturn(T) and record reconstruction
+
+Records are now reconstructed via canonical constructor. POJO behavior
+unchanged. apply(Object) still throws for record root, now with
+IllegalArgumentException recommending applyAndReturn.
+
+Assisted by AI"
+```
+
+---
+
+### Task 10: Add cascade descent into POJO and RECORD child fields
+
+**Files:**
+- Modify: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java`
+- Test: `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCascadeTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCascadeTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class TraversalEngineCascadeTest {
+
+    @Test
+    void cascadeFalseLeavesNestedAnnotatedFieldUntouched_backwardCompat() {
+        final ParentNoCascade parent = new ParentNoCascade();
+        parent.name = "  PARENT  ";
+        parent.child = new Child();
+        parent.child.name = "  CHILD  ";
+        SanitizationUtils.apply(parent);
+        assertEquals("parent", parent.name);
+        // No cascade → child not touched
+        assertEquals("  CHILD  ", parent.child.name);
+    }
+
+    @Test
+    void cascadeTrueIntoPojoMutatesChildInPlace() {
+        final ParentWithCascade parent = new ParentWithCascade();
+        parent.name = "  PARENT  ";
+        parent.child = new Child();
+        parent.child.name = "  CHILD  ";
+        SanitizationUtils.apply(parent);
+        assertEquals("parent", parent.name);
+        assertEquals("child", parent.child.name);
+    }
+
+    @Test
+    void cascadeTrueIntoRecordReplacesField() {
+        final HoldsRecord parent = new HoldsRecord();
+        parent.embedded = new Embedded("  HELLO  ");
+        SanitizationUtils.apply(parent);
+        assertNotSame("  HELLO  ", parent.embedded.value());
+        assertEquals("HELLO", parent.embedded.value());
+    }
+
+    @Test
+    void recordRootCascadesIntoChildRecord() {
+        final OuterRec input = new OuterRec(new InnerRec("  hi  "));
+        final OuterRec out = SanitizationUtils.applyAndReturn(input);
+        assertNotSame(input, out);
+        assertEquals("HI", out.inner().value());
+    }
+
+    @Test
+    void cascadeOnlyAnnotationDescendsWithoutSelfSanitizer() {
+        final OnlyCascade parent = new OnlyCascade();
+        parent.child = new Child();
+        parent.child.name = "  CHILD  ";
+        SanitizationUtils.apply(parent);
+        assertEquals("child", parent.child.name);
+    }
+
+    @Test
+    void sharedRecordReferenceProducesSameReconstructedInstance() {
+        final Shared input = new Shared(new InnerRec("  hi  "));
+        final HoldsTwo parent = new HoldsTwo();
+        parent.left = input;
+        parent.right = input;
+        SanitizationUtils.apply(parent);
+        // The shared reference inside both Shared records is the same after
+        // reconstruction.
+        assertSame(parent.left.inner(), parent.right.inner());
+        assertEquals("HI", parent.left.inner().value());
+    }
+
+    static class ParentNoCascade {
+        @Sanitize(using = io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer.class)
+        String name;
+        Child child;
+    }
+
+    static class ParentWithCascade {
+        @Sanitize(using = io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer.class)
+        String name;
+        @Sanitize(cascade = true)
+        Child child;
+    }
+
+    static class Child {
+        @Sanitize(using = {TrimSanitizer.class, io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer.class})
+        String name;
+    }
+
+    static class HoldsRecord {
+        @Sanitize(cascade = true)
+        Embedded embedded;
+    }
+
+    record Embedded(@Sanitize(using = {TrimSanitizer.class, UpperCaseSanitizer.class}) String value) {}
+
+    record OuterRec(@Sanitize(cascade = true) InnerRec inner) {}
+    record InnerRec(@Sanitize(using = {TrimSanitizer.class, UpperCaseSanitizer.class}) String value) {}
+
+    static class OnlyCascade {
+        @Sanitize(cascade = true)
+        Child child;
+    }
+
+    record Shared(@Sanitize(cascade = true) InnerRec inner) {}
+
+    static class HoldsTwo {
+        @Sanitize(cascade = true) Shared left;
+        @Sanitize(cascade = true) Shared right;
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngineCascadeTest"`
+Expected: multiple failures — nested fields not sanitized; record cascade not wired.
+
+Some sub-tests (`cascadeFalseLeavesNestedAnnotatedFieldUntouched_backwardCompat`) should PASS already — that's intentional, verifying the backward-compat guarantee.
+
+- [ ] **Step 3: Add cascade descent to `TraversalEngine.walkPojo` and `walkRecord`**
+
+Edit `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java`. Replace the two methods `walkPojo` and `walkRecord` (and add a private helper `descendByKind`) so that the file becomes:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.RecordComponent;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizerInstantiationException;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+public final class TraversalEngine {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TraversalEngine.class);
+
+    private TraversalEngine() {
+    }
+
+    public static @Nullable Object walk(
+            final @Nullable Object node,
+            final TraversalState state,
+            final TraversalSafetyChecker checker) {
+        if (node == null) {
+            return null;
+        }
+        final ClassMetadata meta = ClassMetadata.of(node.getClass());
+        if (meta.isRecord()) {
+            final Object cached = state.findReconstructed(node);
+            if (cached != null) {
+                return cached;
+            }
+            final Object built = walkRecord(node, meta, state, checker);
+            state.storeReconstructed(node, built);
+            return built;
+        }
+        if (!state.markVisited(node)) {
+            return node;
+        }
+        walkPojo(node, meta, state, checker);
+        return node;
+    }
+
+    private static Object walkRecord(
+            final Object node, final ClassMetadata meta, final TraversalState state,
+            final TraversalSafetyChecker checker) {
+        LOG.debug("walk record class={} components={}", node.getClass().getName(), meta.fields().size());
+        final RecordComponent[] components = meta.components();
+        final Object[] args = new Object[components.length];
+        for (int i = 0; i < components.length; i++) {
+            final RecordComponent rc = components[i];
+            final FieldDescriptor d = meta.fields().get(i);
+            try {
+                final Object raw = rc.getAccessor().invoke(node);
+                Object current = applyChain(raw, d.chain());
+                if (d.cascade() && current != null) {
+                    current = descendByKind(current, d, state, checker);
+                }
+                args[i] = current;
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(
+                        "Cannot invoke accessor for component '" + rc.getName() + "' on " + node.getClass().getName(),
+                        e);
+            } catch (final InvocationTargetException e) {
+                rethrowRuntime(e, "Record accessor threw");
+            } catch (final ClassCastException e) {
+                throw new IllegalStateException(
+                        "Type mismatch: sanitizer chain incompatible with record component '"
+                                + rc.getName() + "' of type " + rc.getType().getName()
+                                + " on " + node.getClass().getName(),
+                        e);
+            }
+        }
+        try {
+            return meta.canonicalCtor().newInstance(args);
+        } catch (final InvocationTargetException e) {
+            rethrowRuntime(e, "Record canonical constructor threw checked exception");
+            return null; // unreachable
+        } catch (final ReflectiveOperationException e) {
+            throw new SanitizerInstantiationException(
+                    "Cannot reconstruct record " + node.getClass().getName(), e);
+        }
+    }
+
+    private static void walkPojo(
+            final Object node, final ClassMetadata meta, final TraversalState state,
+            final TraversalSafetyChecker checker) {
+        LOG.debug("walk pojo class={} fields={}", node.getClass().getName(), meta.fields().size());
+        for (final FieldDescriptor d : meta.fields()) {
+            final Field field = d.field();
+            if (field == null) {
+                continue;
+            }
+            try {
+                final Object raw = field.get(node);
+                Object sanitized = applyChain(raw, d.chain());
+                writeBackIfChanged(node, field, raw, sanitized);
+                if (d.cascade() && sanitized != null && checker.shouldDescend(node, field)) {
+                    final Object after = descendByKind(sanitized, d, state, checker);
+                    if (after != sanitized) {
+                        field.set(node, after);
+                    }
+                }
+            } catch (final IllegalAccessException e) {
+                throw new IllegalStateException(
+                        "Cannot access field '" + field.getName() + "' on " + node.getClass().getName()
+                                + ". Ensure the field is mutable and accessible.",
+                        e);
+            } catch (final ClassCastException e) {
+                throw new IllegalStateException(
+                        "Type mismatch: sanitizer chain incompatible with field '" + field.getName()
+                                + "' of type " + field.getType().getName() + " on " + node.getClass().getName()
+                                + ". Ensure the sanitizer's generic type matches the field type.",
+                        e);
+            }
+        }
+    }
+
+    private static Object descendByKind(
+            final Object child, final FieldDescriptor d, final TraversalState state,
+            final TraversalSafetyChecker checker) {
+        switch (d.kind()) {
+            case POJO -> {
+                walk(child, state, checker);
+                return child;
+            }
+            case RECORD -> {
+                final Object replaced = walk(child, state, checker);
+                return replaced == null ? child : replaced;
+            }
+            case COLLECTION, MAP -> {
+                // Implemented in a later task.
+                LOG.warn("cascade into {} not yet implemented; skipping", d.kind());
+                return child;
+            }
+            case LEAF -> throw new IllegalStateException(
+                    "Internal error: cascade descent reached LEAF for "
+                            + (d.field() != null ? d.field().getName() : d.recordComponent().getName()));
+        }
+        return child;
+    }
+
+    private static @Nullable Object applyChain(final @Nullable Object raw, final List<FieldSanitizer<Object>> chain) {
+        Object current = raw;
+        for (final FieldSanitizer<Object> s : chain) {
+            current = s.sanitize(current);
+        }
+        return current;
+    }
+
+    private static void writeBackIfChanged(
+            final Object node, final Field field, final @Nullable Object raw, final @Nullable Object sanitized)
+            throws IllegalAccessException {
+        if (raw == null && sanitized == null) {
+            return;
+        }
+        field.set(node, sanitized);
+    }
+
+    private static void rethrowRuntime(final InvocationTargetException e, final String fallback) {
+        final Throwable cause = e.getCause() != null ? e.getCause() : e;
+        if (cause instanceof RuntimeException re) {
+            throw re;
+        }
+        throw new IllegalStateException(fallback, cause);
+    }
+}
+```
+
+- [ ] **Step 4: Run the cascade test**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngineCascadeTest"`
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Run all sanitizer-core tests**
+
+Run: `./gradlew :sanitizer-core:check`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java \
+        sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCascadeTest.java
+git commit -m "feat(core): add cascade descent into POJO and RECORD child fields
+
+Cascade into Collection/Map is logged as a WARN and skipped until the
+next task implements collection support.
+
+Assisted by AI"
+```
+
+---
+
+### Task 11: Add Collection support — leaf elements, record elements, mutable POJO elements
+
+**Files:**
+- Create: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/CollectionWalker.java`
+- Modify: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java`
+- Test: `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCollectionTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCollectionTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TraversalEngineCollectionTest {
+
+    @Test
+    void listOfStringsLeafSanitizedInPlace() {
+        final WithStringList b = new WithStringList();
+        b.values = new ArrayList<>(List.of("  A  ", "  B  "));
+        final List<String> before = b.values;
+        SanitizationUtils.apply(b);
+        assertSame(before, b.values);
+        assertEquals(List.of("a", "b"), b.values);
+    }
+
+    @Test
+    void unmodifiableListOfStringsLeafSanitizedRebuiltAsArrayList() {
+        final WithStringList b = new WithStringList();
+        b.values = List.of("  A  ", "  B  ");
+        final List<String> before = b.values;
+        SanitizationUtils.apply(b);
+        assertNotSame(before, b.values);
+        assertTrue(b.values instanceof ArrayList<?>);
+        assertEquals(List.of("a", "b"), b.values);
+    }
+
+    @Test
+    void listOfRecordsRebuiltWithSanitizedInstances() {
+        final WithRecordList b = new WithRecordList();
+        b.items = new ArrayList<>(List.of(new Item("  HI  "), new Item("  YO  ")));
+        final List<Item> before = b.items;
+        SanitizationUtils.apply(b);
+        assertNotSame(before, b.items);
+        assertEquals("HI", b.items.get(0).value());
+        assertEquals("YO", b.items.get(1).value());
+    }
+
+    @Test
+    void listOfMutablePojosWalkedInPlace() {
+        final WithPojoList b = new WithPojoList();
+        b.children = new ArrayList<>(List.of(new Child("  A  "), new Child("  B  ")));
+        final List<Child> before = b.children;
+        final Child first = before.get(0);
+        SanitizationUtils.apply(b);
+        assertSame(before, b.children);
+        assertSame(first, b.children.get(0));
+        assertEquals("a", b.children.get(0).name);
+        assertEquals("b", b.children.get(1).name);
+    }
+
+    @Test
+    void setOfStringsRebuiltAsLinkedHashSetPreservingOrder() {
+        final WithStringSet b = new WithStringSet();
+        b.values = new LinkedHashSet<>(List.of("  A  ", "  B  ", "  C  "));
+        SanitizationUtils.apply(b);
+        final Iterator<String> it = b.values.iterator();
+        assertEquals("a", it.next());
+        assertEquals("b", it.next());
+        assertEquals("c", it.next());
+    }
+
+    @Test
+    void unmodifiableSetOfRecordsRebuilt() {
+        final WithRecordSet b = new WithRecordSet();
+        b.items = Set.of(new Item("  HI  "));
+        SanitizationUtils.apply(b);
+        assertEquals(1, b.items.size());
+        assertEquals("HI", b.items.iterator().next().value());
+    }
+
+    @Test
+    void rawCollectionFieldWithCascadeIsSkippedGracefully() {
+        // No element type → cascade is a no-op; should not throw.
+        final RawHolder b = new RawHolder();
+        b.raw = new ArrayList<Object>(List.of("ignored"));
+        SanitizationUtils.apply(b);
+        assertEquals(List.of("ignored"), b.raw);
+    }
+
+    static class WithStringList {
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) List<String> values;
+    }
+
+    static class WithRecordList {
+        @Sanitize(cascade = true) List<Item> items;
+    }
+
+    static class WithPojoList {
+        @Sanitize(cascade = true) List<Child> children;
+    }
+
+    static class WithStringSet {
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) Set<String> values;
+    }
+
+    static class WithRecordSet {
+        @Sanitize(cascade = true) Set<Item> items;
+    }
+
+    record Item(@Sanitize(using = {TrimSanitizer.class, UpperCaseSanitizer.class}) String value) {}
+
+    static class Child {
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) String name;
+        Child() {}
+        Child(final String name) { this.name = name; }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    static class RawHolder {
+        @Sanitize(cascade = true) List raw;
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngineCollectionTest"`
+Expected: multiple failures — collection cascade is currently a no-op WARN.
+
+- [ ] **Step 3: Create `CollectionWalker`**
+
+Create `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/CollectionWalker.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+/** Cascade descent into {@link Collection} fields. */
+final class CollectionWalker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CollectionWalker.class);
+
+    private CollectionWalker() {
+    }
+
+    /**
+     * Walks a collection. Returns the same reference when elements are mutated
+     * in place; returns a new collection when the original is unmodifiable or
+     * when elements are records (immutable).
+     */
+    static Collection<?> walk(
+            final Collection<?> coll,
+            final @Nullable Class<?> elementType,
+            final List<FieldSanitizer<Object>> chain,
+            final TraversalState state,
+            final TraversalSafetyChecker checker) {
+        if (elementType == null) {
+            LOG.warn("collection field has no resolvable element type; skipping cascade");
+            return coll;
+        }
+        final Kind elementKind = kindOf(elementType);
+        final boolean isUnmodifiable = isUnmodifiable(coll);
+        final boolean rebuild = isUnmodifiable || elementKind == Kind.RECORD;
+
+        if (rebuild) {
+            return rebuild(coll, elementKind, chain, state, checker);
+        }
+        // Mutable in-place path
+        if (coll instanceof List<?>) {
+            walkListInPlace((List<Object>) coll, elementKind, chain, state, checker);
+            return coll;
+        }
+        if (coll instanceof Set<?>) {
+            // Sets: rebuild even when mutable, because hash codes may change for
+            // records and leaf-sanitized strings.
+            return rebuild(coll, elementKind, chain, state, checker);
+        }
+        // Other Collection: rebuild as ArrayList
+        return rebuild(coll, elementKind, chain, state, checker);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void walkListInPlace(
+            final List<Object> list,
+            final Kind elementKind,
+            final List<FieldSanitizer<Object>> chain,
+            final TraversalState state,
+            final TraversalSafetyChecker checker) {
+        for (int i = 0; i < list.size(); i++) {
+            final Object raw = list.get(i);
+            final Object processed = processElement(raw, elementKind, chain, state, checker);
+            if (processed != raw) {
+                list.set(i, processed);
+            }
+        }
+    }
+
+    private static Collection<?> rebuild(
+            final Collection<?> source,
+            final Kind elementKind,
+            final List<FieldSanitizer<Object>> chain,
+            final TraversalState state,
+            final TraversalSafetyChecker checker) {
+        final Collection<Object> target = source instanceof Set<?>
+                ? new LinkedHashSet<>(source.size())
+                : new ArrayList<>(source.size());
+        for (final Object raw : source) {
+            target.add(processElement(raw, elementKind, chain, state, checker));
+        }
+        return target;
+    }
+
+    private static @Nullable Object processElement(
+            final @Nullable Object raw,
+            final Kind elementKind,
+            final List<FieldSanitizer<Object>> chain,
+            final TraversalState state,
+            final TraversalSafetyChecker checker) {
+        if (raw == null) {
+            return null;
+        }
+        Object current = raw;
+        for (final FieldSanitizer<Object> s : chain) {
+            current = s.sanitize(current);
+        }
+        if (elementKind == Kind.POJO || elementKind == Kind.RECORD) {
+            final Object after = TraversalEngine.walk(current, state, checker);
+            current = after == null ? current : after;
+        }
+        return current;
+    }
+
+    private static Kind kindOf(final Class<?> elementType) {
+        if (elementType.isRecord()) {
+            return Kind.RECORD;
+        }
+        if (Collection.class.isAssignableFrom(elementType) || java.util.Map.class.isAssignableFrom(elementType)) {
+            // Nested collections within collections are out of scope for v1.2.0;
+            // treat as POJO so the engine descends into the wrapper.
+            return Kind.POJO;
+        }
+        if (elementType.isPrimitive() || elementType.isEnum()
+                || elementType == String.class || elementType == Integer.class || elementType == Long.class
+                || elementType == Boolean.class || elementType == java.util.UUID.class
+                || elementType == java.time.Instant.class) {
+            return Kind.LEAF;
+        }
+        return Kind.POJO;
+    }
+
+    private static boolean isUnmodifiable(final Collection<?> coll) {
+        final String name = coll.getClass().getName();
+        return name.startsWith("java.util.ImmutableCollections$")
+                || name.startsWith("java.util.Collections$Unmodifiable");
+    }
+}
+```
+
+- [ ] **Step 4: Wire `CollectionWalker` into `TraversalEngine.descendByKind`**
+
+Edit `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java`. Replace the `COLLECTION, MAP` branch in `descendByKind` and add the import:
+
+Find:
+```java
+            case COLLECTION, MAP -> {
+                // Implemented in a later task.
+                LOG.warn("cascade into {} not yet implemented; skipping", d.kind());
+                return child;
+            }
+```
+
+Replace with:
+```java
+            case COLLECTION -> {
+                return CollectionWalker.walk(
+                        (java.util.Collection<?>) child, d.elementType(), d.chain(), state, checker);
+            }
+            case MAP -> {
+                // Implemented in the next task.
+                LOG.warn("cascade into MAP not yet implemented; skipping");
+                return child;
+            }
+```
+
+- [ ] **Step 5: Run the collection test**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngineCollectionTest"`
+Expected: 7 tests pass.
+
+- [ ] **Step 6: Run all sanitizer-core tests**
+
+Run: `./gradlew :sanitizer-core:check`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/CollectionWalker.java \
+        sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java \
+        sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCollectionTest.java
+git commit -m "feat(core): cascade descent into Collection fields
+
+Mutable Lists walk in place; Sets always rebuild as LinkedHashSet (hash
+may change after sanitization); unmodifiable collections rebuild as
+ArrayList. Records-as-elements always rebuild.
+
+Assisted by AI"
+```
+
+---
+
+### Task 12: Add Map support — values walked, keys untouched
+
+**Files:**
+- Create: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/MapWalker.java`
+- Modify: `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java`
+- Test: `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineMapTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineMapTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class TraversalEngineMapTest {
+
+    @Test
+    void mapOfStringToRecordRebuiltWithSanitizedValues() {
+        final Bean b = new Bean();
+        b.byKey = new LinkedHashMap<>();
+        b.byKey.put("a", new Item("  HI  "));
+        b.byKey.put("b", new Item("  YO  "));
+        final Map<String, Item> before = b.byKey;
+        SanitizationUtils.apply(b);
+        // Map ref may stay the same (mutable HashMap), values are replaced.
+        assertEquals("HI", b.byKey.get("a").value());
+        assertEquals("YO", b.byKey.get("b").value());
+        assertSame(before, b.byKey);
+    }
+
+    @Test
+    void mapKeysUntouched() {
+        final Bean b = new Bean();
+        b.byKey = new HashMap<>();
+        b.byKey.put("  KEY  ", new Item("  V  "));
+        SanitizationUtils.apply(b);
+        // Keys remain untouched; the original raw key is still present.
+        assertEquals(1, b.byKey.size());
+        assertSame("  KEY  ", b.byKey.keySet().iterator().next());
+        assertEquals("V", b.byKey.get("  KEY  ").value());
+    }
+
+    @Test
+    void unmodifiableMapRebuilt() {
+        final Bean b = new Bean();
+        b.byKey = Map.of("a", new Item("  X  "));
+        final Map<String, Item> before = b.byKey;
+        SanitizationUtils.apply(b);
+        assertNotSame(before, b.byKey);
+        assertEquals("X", b.byKey.get("a").value());
+    }
+
+    static class Bean {
+        @Sanitize(cascade = true)
+        Map<String, Item> byKey;
+    }
+
+    record Item(@Sanitize(using = {TrimSanitizer.class, UpperCaseSanitizer.class}) String value) {}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngineMapTest"`
+Expected: failures — map cascade currently a no-op WARN.
+
+- [ ] **Step 3: Create `MapWalker`**
+
+Create `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/MapWalker.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+/** Cascade descent into {@link Map} fields. Keys are never inspected. */
+final class MapWalker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MapWalker.class);
+
+    private MapWalker() {
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static Map<?, ?> walk(
+            final Map<?, ?> map,
+            final @Nullable Class<?> valueType,
+            final List<FieldSanitizer<Object>> chain,
+            final TraversalState state,
+            final TraversalSafetyChecker checker) {
+        if (valueType == null) {
+            LOG.warn("map field has no resolvable value type; skipping cascade");
+            return map;
+        }
+        final boolean rebuild = isUnmodifiable(map) || valueType.isRecord();
+        if (rebuild) {
+            final Map<Object, Object> target = new LinkedHashMap<>(map.size());
+            for (final Map.Entry<?, ?> e : map.entrySet()) {
+                target.put(e.getKey(), processValue(e.getValue(), valueType, chain, state, checker));
+            }
+            return target;
+        }
+        // Mutable + non-record value: walk values in place via replaceAll.
+        ((Map) map).replaceAll((k, v) -> processValue(v, valueType, chain, state, checker));
+        return map;
+    }
+
+    private static @Nullable Object processValue(
+            final @Nullable Object raw,
+            final Class<?> valueType,
+            final List<FieldSanitizer<Object>> chain,
+            final TraversalState state,
+            final TraversalSafetyChecker checker) {
+        if (raw == null) {
+            return null;
+        }
+        Object current = raw;
+        for (final FieldSanitizer<Object> s : chain) {
+            current = s.sanitize(current);
+        }
+        if (valueType.isRecord() || !(valueType.isPrimitive() || valueType == String.class)) {
+            final Object after = TraversalEngine.walk(current, state, checker);
+            current = after == null ? current : after;
+        }
+        return current;
+    }
+
+    private static boolean isUnmodifiable(final Map<?, ?> map) {
+        final String name = map.getClass().getName();
+        return name.startsWith("java.util.ImmutableCollections$")
+                || name.startsWith("java.util.Collections$Unmodifiable");
+    }
+}
+```
+
+- [ ] **Step 4: Wire `MapWalker` into `TraversalEngine.descendByKind`**
+
+Edit `sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java`. Replace the `case MAP` branch with:
+
+```java
+            case MAP -> {
+                return MapWalker.walk(
+                        (java.util.Map<?, ?>) child, d.elementType(), d.chain(), state, checker);
+            }
+```
+
+- [ ] **Step 5: Run map test**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngineMapTest"`
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Run all sanitizer-core tests**
+
+Run: `./gradlew :sanitizer-core:check`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/MapWalker.java \
+        sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java \
+        sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineMapTest.java
+git commit -m "feat(core): cascade descent into Map values (keys untouched)
+
+Assisted by AI"
+```
+
+---
+
+### Task 13: Add cycle detection test
+
+The engine already calls `state.markVisited(node)` in `walk`. This task adds a regression test to lock the behavior in.
+
+**Files:**
+- Test: `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCycleTest.java`
+
+- [ ] **Step 1: Write the test**
+
+Create `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCycleTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+
+class TraversalEngineCycleTest {
+
+    @Test
+    void bidirectionalCycleTerminatesAndLabelsSanitizedOnce() {
+        final Node a = new Node();
+        a.label = "  A  ";
+        final Node b = new Node();
+        b.label = "  B  ";
+        a.next = b;
+        b.next = a;
+        assertTimeout(java.time.Duration.ofSeconds(2), () -> SanitizationUtils.apply(a));
+        assertEquals("a", a.label);
+        assertEquals("b", b.label);
+        assertSame(b, a.next);
+        assertSame(a, b.next);
+    }
+
+    static class Node {
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) String label;
+        @Sanitize(cascade = true) Node next;
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngineCycleTest"`
+Expected: test passes (cycle detection already wired via `markVisited`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCycleTest.java
+git commit -m "test(core): lock in cycle-detection behavior for POJO graphs
+
+Assisted by AI"
+```
+
+---
+
+### Task 14: Add `TraversalSafetyChecker` integration test
+
+**Files:**
+- Test: `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineSafetyCheckerTest.java`
+
+- [ ] **Step 1: Write the test**
+
+Create `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineSafetyCheckerTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TraversalEngineSafetyCheckerTest {
+
+    @Test
+    void checkerReturningFalseSkipsDescentButRunsSelfSanitizers() {
+        final Parent p = new Parent();
+        p.name = "  PARENT  ";
+        p.child = new Child();
+        p.child.name = "  CHILD  ";
+        final TraversalSafetyChecker neverDescend = (parent, field) -> false;
+        SanitizationUtils.applyAndReturn(p, neverDescend);
+        assertEquals("parent", p.name);
+        // Cascade skipped → child name untouched.
+        assertEquals("  CHILD  ", p.child.name);
+    }
+
+    @Test
+    void checkerReturningTrueAllowsDescent() {
+        final Parent p = new Parent();
+        p.name = "  PARENT  ";
+        p.child = new Child();
+        p.child.name = "  CHILD  ";
+        SanitizationUtils.applyAndReturn(p, TraversalSafetyChecker.ALWAYS);
+        assertEquals("parent", p.name);
+        assertEquals("child", p.child.name);
+    }
+
+    static class Parent {
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) String name;
+        @Sanitize(cascade = true) Child child;
+    }
+
+    static class Child {
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) String name;
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngineSafetyCheckerTest"`
+Expected: both tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineSafetyCheckerTest.java
+git commit -m "test(core): verify TraversalSafetyChecker gates cascade descent
+
+Assisted by AI"
+```
+
+---
+
+### Task 15: Add backward-compat regression test for nested-without-cascade
+
+**Files:**
+- Test: `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtilsBackwardCompatTest.java`
+
+- [ ] **Step 1: Write the test**
+
+Create `sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtilsBackwardCompatTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.core;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SanitizationUtilsBackwardCompatTest {
+
+    @Test
+    void nestedAnnotatedFieldUntouchedWhenCascadeOmitted() {
+        final Parent p = new Parent();
+        p.name = "  PARENT  ";
+        p.child = new Child();
+        p.child.name = "  CHILD  ";
+        SanitizationUtils.apply(p);
+        assertEquals("parent", p.name);
+        // Without cascade=true the engine must not descend.
+        assertEquals("  CHILD  ", p.child.name);
+    }
+
+    static class Parent {
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) String name;
+        Child child;  // no @Sanitize on field → not annotated, not walked
+    }
+
+    static class Child {
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) String name;
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew :sanitizer-core:test --tests "io.github.rabinarayanpatra.sanitizer.core.SanitizationUtilsBackwardCompatTest"`
+Expected: test passes (backward compat guarantee).
+
+- [ ] **Step 3: Final core check**
+
+Run: `./gradlew :sanitizer-core:check`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtilsBackwardCompatTest.java
+git commit -m "test(core): lock in 1.1.0 behavior for nested fields without cascade
+
+Assisted by AI"
+```
+
+---
+
+## Phase 4: Spring (Jackson) module update
+
+### Task 16: Update `SanitizerModule` to use `applyAndReturn`
+
+**Files:**
+- Modify: `sanitizer-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/spring/jackson/SanitizerModule.java`
+- Test: `sanitizer-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/spring/jackson/SanitizerModuleRecordIntegrationTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sanitizer-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/spring/jackson/SanitizerModuleRecordIntegrationTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.spring.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SanitizerModuleRecordIntegrationTest {
+
+    @Test
+    void deserializeRecord_sanitizesComponents() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper().registerModule(new SanitizerModule());
+        final RecordDto dto = mapper.readValue("{\"value\":\"  hi  \"}", RecordDto.class);
+        assertEquals("HI", dto.value());
+    }
+
+    @Test
+    void deserializeNestedRecordWithCascade_sanitizesNested() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper().registerModule(new SanitizerModule());
+        final OuterDto dto = mapper.readValue(
+                "{\"inner\":{\"value\":\"  hi  \"}}",
+                OuterDto.class);
+        assertEquals("HI", dto.inner().value());
+    }
+
+    record RecordDto(@Sanitize(using = {TrimSanitizer.class, UpperCaseSanitizer.class}) String value) {}
+
+    record OuterDto(@Sanitize(cascade = true) RecordDto inner) {}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :sanitizer-spring:test --tests "io.github.rabinarayanpatra.sanitizer.spring.jackson.SanitizerModuleRecordIntegrationTest"`
+Expected: failure — current `SanitizingDeserializer` calls `apply(bean)` which throws on records.
+
+- [ ] **Step 3: Update `SanitizerModule`**
+
+Edit `sanitizer-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/spring/jackson/SanitizerModule.java`. Replace the `deserialize` method body so the class becomes:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.spring.jackson;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+
+/**
+ * Jackson module that integrates with Spring Boot to apply
+ * {@link io.github.rabinarayanpatra.sanitizer.annotation.Sanitize} annotations
+ * during JSON deserialization. Records are reconstructed via the engine and
+ * the new instance is returned in place of the raw deserialized record.
+ *
+ * @since 1.0.0
+ */
+public final class SanitizerModule extends SimpleModule {
+
+    public SanitizerModule() {
+        super("SanitizerModule");
+        setDeserializerModifier(new MyBeanDeserializerModifier());
+    }
+
+    private static class SanitizingDeserializer extends DelegatingDeserializer {
+
+        protected SanitizingDeserializer(final JsonDeserializer<?> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public Object deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException {
+            final Object bean = super.deserialize(p, ctxt);
+            return SanitizationUtils.applyAndReturn(bean);
+        }
+
+        @Override
+        protected JsonDeserializer<?> newDelegatingInstance(final JsonDeserializer<?> newDelegate) {
+            return new SanitizingDeserializer(newDelegate);
+        }
+    }
+
+    private static class MyBeanDeserializerModifier extends BeanDeserializerModifier {
+        @Override
+        public JsonDeserializer<?> modifyDeserializer(final DeserializationConfig config,
+                final BeanDescription beanDesc, final JsonDeserializer<?> deserializer) {
+            return new SanitizingDeserializer(deserializer);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `./gradlew :sanitizer-spring:test --tests "io.github.rabinarayanpatra.sanitizer.spring.jackson.SanitizerModuleRecordIntegrationTest"`
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Full spring module check**
+
+Run: `./gradlew :sanitizer-spring:check`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sanitizer-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/spring/jackson/SanitizerModule.java \
+        sanitizer-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/spring/jackson/SanitizerModuleRecordIntegrationTest.java
+git commit -m "feat(spring): wire Jackson deserializer through applyAndReturn
+
+Records and cascaded graphs now sanitize on inbound JSON.
+
+Assisted by AI"
+```
+
+---
+
+## Phase 5: JPA listener update
+
+### Task 17: Update `SanitizationEntityListener` to accept a safety checker and use `applyAndReturn`
+
+**Files:**
+- Modify: `sanitizer-jpa/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/SanitizationEntityListener.java`
+- Test: `sanitizer-jpa/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/SanitizationEntityListenerTest.java`
+
+- [ ] **Step 1: Inspect current listener**
+
+Run: `cat /Volumes/Work/sanitizer-lib/sanitizer-jpa/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/SanitizationEntityListener.java`
+Expected: a class with `@PrePersist @PreUpdate void onSave(Object entity)` that calls `SanitizationUtils.apply(entity)`.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `sanitizer-jpa/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/SanitizationEntityListenerTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.jpa;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SanitizationEntityListenerTest {
+
+    @Test
+    void onSaveSanitizesTopLevelFields() {
+        final Entity e = new Entity();
+        e.name = "  HELLO  ";
+        new SanitizationEntityListener().onSave(e);
+        assertEquals("hello", e.name);
+    }
+
+    @Test
+    void customSafetyCheckerIsHonored() {
+        final Parent p = new Parent();
+        p.name = "  PARENT  ";
+        p.child = new Child();
+        p.child.name = "  CHILD  ";
+        final SanitizationEntityListener listener = new SanitizationEntityListener();
+        listener.setSafetyChecker((parent, field) -> false);
+        listener.onSave(p);
+        assertEquals("parent", p.name);
+        assertEquals("  CHILD  ", p.child.name);
+    }
+
+    @Test
+    void defaultSafetyCheckerAllowsDescent() {
+        final Parent p = new Parent();
+        p.name = "  PARENT  ";
+        p.child = new Child();
+        p.child.name = "  CHILD  ";
+        final SanitizationEntityListener listener = new SanitizationEntityListener();
+        listener.setSafetyChecker(TraversalSafetyChecker.ALWAYS);
+        listener.onSave(p);
+        assertEquals("parent", p.name);
+        assertEquals("child", p.child.name);
+    }
+
+    static class Entity {
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) String name;
+    }
+
+    static class Parent {
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) String name;
+        @Sanitize(cascade = true) Child child;
+    }
+
+    static class Child {
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) String name;
+    }
+}
+```
+
+- [ ] **Step 2 (run): verify it fails**
+
+Run: `./gradlew :sanitizer-jpa:test --tests "io.github.rabinarayanpatra.sanitizer.jpa.SanitizationEntityListenerTest"`
+Expected: COMPILATION FAILURE — `setSafetyChecker` does not exist.
+
+- [ ] **Step 3: Update the listener**
+
+Replace contents of `sanitizer-jpa/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/SanitizationEntityListener.java` with:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.jpa;
+
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+/**
+ * JPA entity listener that applies sanitizers before persist and before update.
+ * Wire it up by annotating an entity (or a {@code @MappedSuperclass}) with
+ * {@code @EntityListeners(SanitizationEntityListener.class)}.
+ *
+ * <p>
+ * In a Spring + Hibernate context, the listener is instantiated by Hibernate.
+ * Use the {@code sanitizer-jpa-spring} starter to wire a Hibernate-aware
+ * {@link TraversalSafetyChecker} that skips lazy associations.
+ *
+ * @since 1.0.0
+ */
+public class SanitizationEntityListener {
+
+    private TraversalSafetyChecker safetyChecker = TraversalSafetyChecker.ALWAYS;
+
+    /**
+     * Overrides the default {@link TraversalSafetyChecker#ALWAYS} checker.
+     * Spring auto-configuration in {@code sanitizer-jpa-spring} calls this with a
+     * Hibernate-aware implementation.
+     *
+     * @param safetyChecker
+     *            the checker to use for all subsequent {@link #onSave(Object)}
+     *            invocations; must not be null
+     */
+    public void setSafetyChecker(final TraversalSafetyChecker safetyChecker) {
+        this.safetyChecker = safetyChecker;
+    }
+
+    @PrePersist
+    @PreUpdate
+    public void onSave(final Object entity) {
+        SanitizationUtils.applyAndReturn(entity, safetyChecker);
+    }
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `./gradlew :sanitizer-jpa:test --tests "io.github.rabinarayanpatra.sanitizer.jpa.SanitizationEntityListenerTest"`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Full jpa module check**
+
+Run: `./gradlew :sanitizer-jpa:check`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sanitizer-jpa/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/SanitizationEntityListener.java \
+        sanitizer-jpa/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/SanitizationEntityListenerTest.java
+git commit -m "feat(jpa): support custom TraversalSafetyChecker on entity listener
+
+Listener now routes through applyAndReturn with a configurable checker
+that defaults to ALWAYS. Top-level POJO behavior is unchanged.
+
+Assisted by AI"
+```
+
+---
+
+## Phase 6: New `sanitizer-jpa-spring` module
+
+### Task 18: Add the module to the Gradle build
+
+**Files:**
+- Modify: `settings.gradle.kts`
+- Create: `sanitizer-jpa-spring/build.gradle.kts`
+
+- [ ] **Step 1: Inspect current settings**
+
+Run: `cat /Volumes/Work/sanitizer-lib/settings.gradle.kts`
+Expected:
+```
+rootProject.name = "sanitizer-lib"
+include("sanitizer-core", "sanitizer-spring", "sanitizer-jpa")
+```
+
+- [ ] **Step 2: Add the module to `settings.gradle.kts`**
+
+Replace contents of `/Volumes/Work/sanitizer-lib/settings.gradle.kts` with:
+
+```kotlin
+rootProject.name = "sanitizer-lib"
+include("sanitizer-core", "sanitizer-spring", "sanitizer-jpa", "sanitizer-jpa-spring")
+```
+
+- [ ] **Step 3: Create the module directory and build file**
+
+Run: `mkdir -p /Volumes/Work/sanitizer-lib/sanitizer-jpa-spring/src/main/java /Volumes/Work/sanitizer-lib/sanitizer-jpa-spring/src/test/java /Volumes/Work/sanitizer-lib/sanitizer-jpa-spring/src/main/resources/META-INF/spring`
+
+Create `/Volumes/Work/sanitizer-lib/sanitizer-jpa-spring/build.gradle.kts`:
+
+```kotlin
+dependencies {
+    api(project(":sanitizer-core"))
+    api(project(":sanitizer-jpa"))
+    api(project(":sanitizer-spring"))
+    implementation("org.springframework.boot:spring-boot-autoconfigure")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.h2database:h2")
+}
+```
+
+- [ ] **Step 4: Verify the build can resolve the new module**
+
+Run: `./gradlew :sanitizer-jpa-spring:dependencies --configuration runtimeClasspath | head -30`
+Expected: no errors; shows `sanitizer-core`, `sanitizer-jpa`, `sanitizer-spring`, `spring-boot-starter-data-jpa` resolved.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add settings.gradle.kts sanitizer-jpa-spring/build.gradle.kts
+git commit -m "build: add sanitizer-jpa-spring module to multi-module build
+
+Assisted by AI"
+```
+
+---
+
+### Task 19: Implement `HibernateSafetyChecker`
+
+**Files:**
+- Create: `sanitizer-jpa-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/HibernateSafetyChecker.java`
+- Create: `sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/HibernateSafetyCheckerTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/HibernateSafetyCheckerTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.jpa.spring;
+
+import java.lang.reflect.Field;
+
+import jakarta.persistence.PersistenceUnitUtil;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HibernateSafetyCheckerTest {
+
+    @Test
+    void shouldDescendReturnsFalseForUnloadedFieldName() throws NoSuchFieldException {
+        final PersistenceUnitUtil util = mock(PersistenceUnitUtil.class);
+        final Holder holder = new Holder();
+        final Field field = Holder.class.getDeclaredField("children");
+        when(util.isLoaded(any(), eq("children"))).thenReturn(false);
+        final TraversalSafetyChecker checker = new HibernateSafetyChecker(util);
+        assertFalse(checker.shouldDescend(holder, field));
+    }
+
+    @Test
+    void shouldDescendReturnsTrueForLoadedFieldName() throws NoSuchFieldException {
+        final PersistenceUnitUtil util = mock(PersistenceUnitUtil.class);
+        final Holder holder = new Holder();
+        final Field field = Holder.class.getDeclaredField("children");
+        when(util.isLoaded(any(), eq("children"))).thenReturn(true);
+        final TraversalSafetyChecker checker = new HibernateSafetyChecker(util);
+        assertTrue(checker.shouldDescend(holder, field));
+    }
+
+    static class Holder {
+        java.util.List<String> children;
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :sanitizer-jpa-spring:test --tests "io.github.rabinarayanpatra.sanitizer.jpa.spring.HibernateSafetyCheckerTest"`
+Expected: COMPILATION FAILURE — `HibernateSafetyChecker` not found.
+
+- [ ] **Step 3: Implement `HibernateSafetyChecker`**
+
+Create `sanitizer-jpa-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/HibernateSafetyChecker.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.jpa.spring;
+
+import java.lang.reflect.Field;
+
+import jakarta.persistence.PersistenceUnitUtil;
+
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+/**
+ * {@link TraversalSafetyChecker} that defers to Hibernate's
+ * {@link PersistenceUnitUtil#isLoaded(Object, String)} so the traversal engine
+ * skips lazy associations that have not been initialized.
+ *
+ * @since 1.2.0
+ */
+public final class HibernateSafetyChecker implements TraversalSafetyChecker {
+
+    private final PersistenceUnitUtil util;
+
+    public HibernateSafetyChecker(final PersistenceUnitUtil util) {
+        this.util = util;
+    }
+
+    @Override
+    public boolean shouldDescend(final Object parent, final Field field) {
+        return util.isLoaded(parent, field.getName());
+    }
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `./gradlew :sanitizer-jpa-spring:test --tests "io.github.rabinarayanpatra.sanitizer.jpa.spring.HibernateSafetyCheckerTest"`
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sanitizer-jpa-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/HibernateSafetyChecker.java \
+        sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/HibernateSafetyCheckerTest.java
+git commit -m "feat(jpa-spring): add HibernateSafetyChecker delegating to PersistenceUnitUtil.isLoaded
+
+Assisted by AI"
+```
+
+---
+
+### Task 20: Implement `SanitizerJpaAutoConfiguration` wiring via `SpringBeanContainer`
+
+**Files:**
+- Create: `sanitizer-jpa-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/SanitizerJpaAutoConfiguration.java`
+- Create: `sanitizer-jpa-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`
+- Create: `sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/SanitizerJpaAutoConfigurationTest.java`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/SanitizerJpaAutoConfigurationTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.jpa.spring;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.jpa.SanitizationEntityListener;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DataJpaTest
+@AutoConfigureTestDatabase
+@Import(SanitizerJpaAutoConfiguration.class)
+class SanitizerJpaAutoConfigurationTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Autowired
+    HibernateSafetyChecker checker;
+
+    @Test
+    void contextWiresHibernateSafetyCheckerBean() {
+        assertNotNull(checker);
+    }
+
+    @Test
+    void persistRunsListenerAndSanitizesTopLevelField() {
+        final UserEntity u = new UserEntity();
+        u.email = "  USER@EXAMPLE.COM  ";
+        final UserEntity saved = em.persistFlushFind(u);
+        assertEquals("user@example.com", saved.email);
+    }
+
+    @Entity
+    @EntityListeners(SanitizationEntityListener.class)
+    static class UserEntity implements Serializable {
+        @Id @GeneratedValue Long id;
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) String email;
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :sanitizer-jpa-spring:test --tests "io.github.rabinarayanpatra.sanitizer.jpa.spring.SanitizerJpaAutoConfigurationTest"`
+Expected: failure — `SanitizerJpaAutoConfiguration` does not exist; bean wiring missing.
+
+- [ ] **Step 3: Implement auto-configuration**
+
+Create `sanitizer-jpa-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/SanitizerJpaAutoConfiguration.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.jpa.spring;
+
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnitUtil;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.resource.beans.container.spi.BeanContainer;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.orm.jpa.SharedEntityManagerCreator;
+import org.springframework.orm.jpa.persistenceunit.SpringBeanContainer;
+
+import io.github.rabinarayanpatra.sanitizer.jpa.SanitizationEntityListener;
+
+/**
+ * Spring Boot auto-configuration that exposes a {@link HibernateSafetyChecker}
+ * and configures Hibernate to instantiate {@link SanitizationEntityListener}
+ * through Spring's {@link SpringBeanContainer}. The listener picks up the
+ * checker as a setter-injected dependency.
+ *
+ * @since 1.2.0
+ */
+@AutoConfiguration
+@ConditionalOnClass({EntityManagerFactory.class, BeanContainer.class})
+public class SanitizerJpaAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public HibernateSafetyChecker hibernateSafetyChecker(final EntityManagerFactory emf) {
+        final PersistenceUnitUtil util = emf.getPersistenceUnitUtil();
+        return new HibernateSafetyChecker(util);
+    }
+
+    @Bean
+    @ConditionalOnBean(HibernateSafetyChecker.class)
+    public SanitizationEntityListener sanitizationEntityListener(final HibernateSafetyChecker checker) {
+        final SanitizationEntityListener listener = new SanitizationEntityListener();
+        listener.setSafetyChecker(checker);
+        return listener;
+    }
+
+    @Bean
+    public HibernatePropertiesCustomizer sanitizerSpringBeanContainerCustomizer(
+            final ConfigurableListableBeanFactory beanFactory) {
+        return properties -> properties.put(
+                AvailableSettings.BEAN_CONTAINER, new SpringBeanContainer(beanFactory));
+    }
+
+    // SharedEntityManagerCreator is referenced to ensure Spring's JPA support is on
+    // the classpath at compile time; it is not used at runtime here.
+    @SuppressWarnings("unused")
+    private static final Class<?> SHARED = SharedEntityManagerCreator.class;
+}
+```
+
+- [ ] **Step 4: Register the auto-config**
+
+Create `sanitizer-jpa-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`:
+
+```
+io.github.rabinarayanpatra.sanitizer.jpa.spring.SanitizerJpaAutoConfiguration
+```
+
+- [ ] **Step 5: Run test**
+
+Run: `./gradlew :sanitizer-jpa-spring:test --tests "io.github.rabinarayanpatra.sanitizer.jpa.spring.SanitizerJpaAutoConfigurationTest"`
+Expected: 2 tests pass.
+
+- [ ] **Step 6: Full module check**
+
+Run: `./gradlew :sanitizer-jpa-spring:check`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add sanitizer-jpa-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/SanitizerJpaAutoConfiguration.java \
+        sanitizer-jpa-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports \
+        sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/SanitizerJpaAutoConfigurationTest.java
+git commit -m "feat(jpa-spring): auto-configure HibernateSafetyChecker and listener wiring
+
+Registers a SpringBeanContainer with Hibernate so JPA listener
+instances are sourced from the Spring context with a Hibernate-aware
+safety checker.
+
+Assisted by AI"
+```
+
+---
+
+### Task 21: Integration test — bidirectional lazy association is not eagerly initialized
+
+**Files:**
+- Create: `sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/LazyAssociationIntegrationTest.java`
+
+- [ ] **Step 1: Write the test**
+
+Create `sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/LazyAssociationIntegrationTest.java`:
+
+```java
+package io.github.rabinarayanpatra.sanitizer.jpa.spring;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.jpa.SanitizationEntityListener;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+@AutoConfigureTestDatabase
+@Import(SanitizerJpaAutoConfiguration.class)
+class LazyAssociationIntegrationTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    @Test
+    void persistParentDoesNotInitializeLazyChildren() {
+        final Department dept = new Department();
+        dept.name = "  ENG  ";
+        final Department persisted = em.persistFlushFind(dept);
+        em.clear();
+        final Department reloaded = em.find(Department.class, persisted.id);
+        // children association is lazy and not touched; sanitization must succeed
+        // without LazyInitializationException.
+        reloaded.name = "  ENG-2  ";
+        em.persistAndFlush(reloaded);
+        assertEquals("eng-2", reloaded.name);
+    }
+
+    @Entity
+    @EntityListeners(SanitizationEntityListener.class)
+    static class Department implements Serializable {
+        @Id @GeneratedValue Long id;
+        @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class}) String name;
+        @Sanitize(cascade = true)
+        @OneToMany(mappedBy = "department", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+        List<Employee> employees = new ArrayList<>();
+    }
+
+    @Entity
+    @EntityListeners(SanitizationEntityListener.class)
+    static class Employee implements Serializable {
+        @Id @GeneratedValue Long id;
+        @Sanitize(using = {TrimSanitizer.class, UpperCaseSanitizer.class}) String code;
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "department_id")
+        Department department;
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `./gradlew :sanitizer-jpa-spring:test --tests "io.github.rabinarayanpatra.sanitizer.jpa.spring.LazyAssociationIntegrationTest"`
+Expected: test passes. The Hibernate-aware safety checker prevents touching the lazy `employees` collection.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/LazyAssociationIntegrationTest.java
+git commit -m "test(jpa-spring): verify lazy associations not initialized during sanitization
+
+Assisted by AI"
+```
+
+---
+
+## Phase 7: Site, docs, version
+
+### Task 22: Update `docs/index.html` to list the new module
+
+**Files:**
+- Modify: `docs/index.html`
+
+- [ ] **Step 1: Locate the module list**
+
+Run: `grep -n -E "sanitizer-(core|spring|jpa)" /Volumes/Work/sanitizer-lib/docs/index.html | head -40`
+Expected: lines that render the three current module cards.
+
+- [ ] **Step 2: Add the fourth card**
+
+Edit `docs/index.html`. Within the same container that holds the three existing cards (cards for `sanitizer-core`, `sanitizer-spring`, `sanitizer-jpa`), copy the existing `sanitizer-jpa` block and add a new card with these substitutions:
+
+- Title text: `sanitizer-jpa-spring`
+- Description text: `Spring Boot starter that wires Hibernate-aware safety checks into the JPA entity listener.`
+- Javadoc link href: `javadoc/sanitizer-jpa-spring/`
+
+Concretely the new block follows the exact same HTML structure as the existing `sanitizer-jpa` card so the page renders consistently. Use the existing card as a template — do not invent new CSS classes.
+
+- [ ] **Step 3: Eye-check the file**
+
+Run: `grep -n "sanitizer-jpa-spring" /Volumes/Work/sanitizer-lib/docs/index.html`
+Expected: at least two occurrences (the card title and the javadoc link href).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/index.html
+git commit -m "docs(site): add sanitizer-jpa-spring module card
+
+Assisted by AI"
+```
+
+---
+
+### Task 23: Extend `publish-site.yml` to copy the new module's javadoc
+
+**Files:**
+- Modify: `.github/workflows/publish-site.yml`
+
+- [ ] **Step 1: Locate javadoc copy steps**
+
+Run: `grep -n -E "sanitizer-(core|spring|jpa)" /Volumes/Work/sanitizer-lib/.github/workflows/publish-site.yml`
+Expected: lines that copy the three modules' javadoc directories into the published site.
+
+- [ ] **Step 2: Add the fourth copy step**
+
+Edit `.github/workflows/publish-site.yml`. Wherever the workflow copies `sanitizer-jpa/build/docs/javadoc`, add an identical step that copies `sanitizer-jpa-spring/build/docs/javadoc` into `site/javadoc/sanitizer-jpa-spring/`. Mirror the syntax of the existing steps exactly (same shell, same flags).
+
+- [ ] **Step 3: Validate YAML**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('/Volumes/Work/sanitizer-lib/.github/workflows/publish-site.yml'))" && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/publish-site.yml
+git commit -m "ci: include sanitizer-jpa-spring javadoc in published site
+
+Assisted by AI"
+```
+
+---
+
+### Task 24: Update README with the new module and cascade docs
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Inspect README structure**
+
+Run: `grep -n -E "## |sanitizer-(core|spring|jpa)" /Volumes/Work/sanitizer-lib/README.md | head -40`
+Expected: section headers and module references.
+
+- [ ] **Step 2: Add three additions**
+
+Edit `README.md` to add:
+
+1. In the modules / coordinates section, a row or paragraph for `sanitizer-jpa-spring` with the Maven coordinate `io.github.rabinarayanpatra.sanitizer:sanitizer-jpa-spring:1.2.0` and a one-line description: `"Spring Boot starter wiring Hibernate-aware safety checks into the JPA entity listener (skips lazy associations)."`
+2. A short "Recursive sanitization" sub-section under usage that shows the `@Sanitize(cascade = true)` form and the difference between `apply(Object)` and `applyAndReturn(T)` for records. Use this exact code block:
+
+```java
+record OrderDto(
+        @Sanitize(using = TrimSanitizer.class) String reference,
+        @Sanitize(cascade = true) CustomerDto customer,
+        @Sanitize(cascade = true) List<LineItem> items) {}
+
+// Records: must use applyAndReturn — it returns a new instance.
+OrderDto sanitized = SanitizationUtils.applyAndReturn(rawOrder);
+
+// POJOs: apply mutates in place; applyAndReturn also works and returns
+// the same reference.
+SanitizationUtils.apply(somePojo);
+```
+
+3. A note in the same section: `"Cascade is strictly opt-in in v1.2.0. The default flips on in v2.0.0 alongside a new @SanitizeIgnore opt-out."`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document sanitizer-jpa-spring and recursive sanitization
+
+Assisted by AI"
+```
+
+---
+
+### Task 25: Update `CHANGELOG.md` with the v1.2.0 entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Inspect current CHANGELOG**
+
+Run: `head -40 /Volumes/Work/sanitizer-lib/CHANGELOG.md`
+Expected: shows the v1.1.0 entry at the top.
+
+- [ ] **Step 2: Prepend the v1.2.0 entry**
+
+Edit `CHANGELOG.md`. Add this block immediately below the header (and above the existing v1.1.0 entry):
+
+```markdown
+## [1.2.0] - 2026-06-05
+
+### Added
+- Java records support via new `SanitizationUtils.applyAndReturn(T)` entry point.
+- Opt-in recursive traversal via `@Sanitize(cascade = true)` for nested objects, records, collections, and maps.
+- `TraversalSafetyChecker` interface for pluggable graph-walk gating.
+- New `sanitizer-jpa-spring` module providing `HibernateSafetyChecker` that skips non-initialized lazy JPA associations.
+- SLF4J logging in the traversal engine at DEBUG/TRACE levels.
+
+### Changed
+- `@Sanitize.using()` now defaults to `{}` so a field can opt in to cascade without supplying a self-sanitizer.
+- `SanitizationUtils.apply(record)` throws `IllegalArgumentException` (was `UnsupportedOperationException`) and recommends `applyAndReturn`.
+
+### Compatibility
+- All existing POJO behavior is bit-identical. Cascade is strictly opt-in in this release.
+- The default cascade flag will flip on in v2.0.0 along with a new `@SanitizeIgnore` opt-out annotation.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): add 1.2.0 entry
+
+Assisted by AI"
+```
+
+---
+
+### Task 26: Bump version to 1.2.0
+
+**Files:**
+- Modify: `build.gradle.kts` (root)
+
+- [ ] **Step 1: Inspect version line**
+
+Run: `grep -n "version =" /Volumes/Work/sanitizer-lib/build.gradle.kts`
+Expected: `version = "1.1.0"` line under `allprojects { ... }`.
+
+- [ ] **Step 2: Update version**
+
+Edit `build.gradle.kts`. Replace `version = "1.1.0"` with `version = "1.2.0"`.
+
+- [ ] **Step 3: Verify**
+
+Run: `./gradlew properties | grep '^version:'`
+Expected: `version: 1.2.0`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add build.gradle.kts
+git commit -m "chore(release): bump version to 1.2.0
+
+Assisted by AI"
+```
+
+---
+
+## Phase 8: Full verification
+
+### Task 27: Full aggregated check + coverage
+
+- [ ] **Step 1: Run aggregated build**
+
+Run: `./gradlew check jacocoAggregatedReport`
+Expected: BUILD SUCCESSFUL across all 4 modules.
+
+- [ ] **Step 2: Inspect aggregated coverage**
+
+Run: `python3 -c "import xml.etree.ElementTree as ET; t=ET.parse('/Volumes/Work/sanitizer-lib/build/reports/jacoco/aggregated/jacoco.xml'); c=t.getroot().find('counter[@type=\"LINE\"]'); m,c2=int(c.get('missed')),int(c.get('covered')); print(f'line coverage: {c2/(m+c2)*100:.2f}%')"`
+Expected: `line coverage: 98.00%` or higher.
+
+If coverage drops below 98%, identify uncovered lines via `build/reports/jacoco/aggregated/html/index.html` and add targeted tests before proceeding.
+
+- [ ] **Step 3: Run Spotless apply for any reformatting**
+
+Run: `./gradlew spotlessApply`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Re-run check to ensure formatting did not break anything**
+
+Run: `./gradlew check`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit any spotless changes (if produced)**
+
+```bash
+git add -A
+git diff --cached --quiet || git commit -m "style: spotlessApply after v1.2.0 work
+
+Assisted by AI"
+```
+
+---
+
+### Task 28: Open the pull request
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin feat/v1.2.0-records-and-traversal`
+Expected: branch pushed to origin.
+
+- [ ] **Step 2: Open PR**
+
+Run:
+```bash
+gh pr create --repo rabinarayanpatra/sanitizer-lib \
+    --title "feat: v1.2.0 records support and recursive traversal engine" \
+    --body "$(cat <<'EOF'
+## Summary
+- Add Java records support via new `SanitizationUtils.applyAndReturn(T)` entry point.
+- Add opt-in recursive traversal via `@Sanitize(cascade = true)` for nested objects, records, collections, and maps.
+- Add `TraversalSafetyChecker` interface for pluggable graph-walk gating.
+- Add new `sanitizer-jpa-spring` module with `HibernateSafetyChecker` to skip non-initialized lazy associations.
+- 100% source/binary compatible with v1.1.0. POJO behavior bit-identical without `cascade=true`.
+
+Spec: `docs/superpowers/specs/2026-06-05-records-and-traversal-engine-design.md`
+Plan: `docs/superpowers/plans/2026-06-05-records-and-traversal-engine.md`
+
+## Test plan
+- [ ] CI is green on the PR
+- [ ] Aggregated JaCoCo coverage >= 98%
+- [ ] Smoke test: deserialize a record DTO through Jackson and verify sanitized output
+- [ ] Smoke test: persist a Spring/JPA entity with a lazy association via `@DataJpaTest` and verify no `LazyInitializationException`
+EOF
+)"
+```
+Expected: PR URL printed to stdout. Capture it for the next review cycle.
+
+---
+
+## Self-Review
+
+The plan above covers every requirement in the spec:
+
+- API surface (Task 1, Task 2, Task 9): `cascade`, `@Sanitize.using()` default, `TraversalSafetyChecker`, `applyAndReturn(T)`, `applyAndReturn(T, checker)`.
+- Architecture (Tasks 3-9): `Kind`, `FieldDescriptor`, `ClassMetadata`, `TraversalState`, `TraversalEngine` with separated record/POJO branches.
+- Cascade descent into POJO and RECORD (Task 10).
+- Cascade descent into Collection (Task 11).
+- Cascade descent into Map (Task 12).
+- Cycle detection (Task 13).
+- Safety checker (Task 14).
+- Backward-compat (Task 15).
+- Jackson integration (Task 16).
+- JPA listener checker support (Task 17).
+- New `sanitizer-jpa-spring` module with `HibernateSafetyChecker` and auto-config (Tasks 18-20).
+- Lazy-association integration test (Task 21).
+- Generic erasure handling for raw collections (covered in `CollectionWalker` early-exit with WARN and asserted by `TraversalEngineCollectionTest#rawCollectionFieldWithCascadeIsSkippedGracefully` and `ClassMetadataTest#rawCollectionTypeReturnsNullElementType`).
+- SLF4J logger (Tasks 6, 7, 11, 12).
+- `apply(record)` exception migration (Task 8).
+- Site updates (Tasks 22, 23).
+- README + CHANGELOG (Tasks 24, 25).
+- Version bump (Task 26).
+- Full check + coverage (Task 27).
+- PR (Task 28).
+
+No placeholders. Every code step contains complete, runnable content. Method and type names are consistent across tasks (`applyAndReturn`, `walk`, `walkRecord`, `walkPojo`, `descendByKind`, `setSafetyChecker`, `HibernateSafetyChecker`).
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-06-05-records-and-traversal-engine.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task with two-stage review between tasks.
+
+**2. Inline Execution** — execute the tasks in this session with batch checkpoints.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-06-05-records-and-traversal-engine-design.md
+++ b/docs/superpowers/specs/2026-06-05-records-and-traversal-engine-design.md
@@ -1,0 +1,441 @@
+# Records support and recursive traversal engine
+
+**Status:** Draft
+**Date:** 2026-06-05
+**Target release:** v1.2.0
+**Owner:** rabinarayanpatra
+
+## Goal
+
+Add first-class Java records support to `sanitizer-lib` and unify it with a recursive traversal engine that walks nested POJOs, records, collections, and maps. Ship as a strictly backward-compatible minor release.
+
+## Non-goals
+
+- Default-on cascade behavior (deferred to v2.0.0; opt-in only in v1.2.0)
+- Spring Boot 4 / Jackson 3 BOM upgrade (separate ticket)
+- Caffeine weak-key cache swap (separate ticket)
+- jqwik property-based tests (separate ticket)
+- `@SanitizeIgnore` opt-out annotation (introduced in v2.0.0 alongside default-on cascade)
+- Bean Validation adapter (separate ticket)
+
+## Background
+
+Current `SanitizationUtils.apply(Object)` throws `UnsupportedOperationException` on records because record components are final and cannot be set via reflection. The utility also walks only the top-level declared fields of a POJO: nested objects, collections of records, and map values are not sanitized even when their types carry `@Sanitize` annotations.
+
+For a library positioned as "enterprise-grade input sanitization", surface-only sanitization is a leaky boundary. Real DTO graphs (`OrderDto -> CustomerDto -> AddressDto`, `List<LineItem>`) require recursion.
+
+## Scope decisions
+
+| Decision | Choice | Reason |
+|---|---|---|
+| Recursion scope | Full graph: records + POJOs + collections + maps | Production-grade lib must not stop at surface |
+| Default cascade | Opt-in per field via `cascade=true` (v1.2.0); flips on in v2.0.0 | SemVer minor must not change behavior for existing inputs |
+| Records reconstruction | Canonical constructor invocation, immutable-style | Only legal mechanism for record component mutation |
+| API shape | Add `applyAndReturn(T)`; keep `apply(Object)` void with throw on record root | Existing POJO callers untouched; record root would silently discard if void-returned |
+| Collection element rebuild | Rebuild when element is record or collection is unmodifiable; otherwise mutate in place | Records and `List.of()` are immutable; mutable collections benefit from in-place |
+| Map handling | Walk values only, keys untouched | Keys typically serve as IDs and are not annotated |
+| Cycle detection | `IdentityHashMap` visited-set per traversal | Prevents `StackOverflowError` on bidirectional JPA graphs |
+| JPA lazy safety | Skip non-initialized associations via `PersistenceUnitUtil.isLoaded` | Prevents N+1 query storms and `LazyInitializationException` at flush |
+| JPA wiring path | New `sanitizer-jpa-spring` module for Hibernate-aware wiring | Keeps `sanitizer-jpa` framework-free; clean layering |
+| Architecture | `TraversalEngine` + `ClassMetadata` + `FieldDescriptor` in core | Separates per-class plan from runtime walker; testable units |
+
+## Public API surface (v1.2.0)
+
+### Annotations (`io.github.rabinarayanpatra.sanitizer.annotation`)
+
+`@Sanitize` gains an optional `cascade` attribute. The existing `using` attribute becomes optional (default `{}`) so a field can opt in to cascade without supplying a self-sanitizer.
+
+```java
+@Retention(RUNTIME)
+@Target(FIELD)
+@Repeatable(Sanitizes.class)
+public @interface Sanitize {
+    Class<? extends FieldSanitizer<?>>[] using() default {};
+    String params() default "";
+    boolean cascade() default false;
+}
+```
+
+Annotation usage matrix:
+
+| Annotation form | Effect |
+|---|---|
+| `@Sanitize(using = Trim.class)` | Sanitize this field's value. Top-level only. Existing behavior. |
+| `@Sanitize(cascade = true)` | Descend into this field's object graph. No self-sanitizer applied. |
+| `@Sanitize(using = Trim.class, cascade = true)` | Sanitize value, then descend. |
+| Field without `@Sanitize` | Untouched. Existing behavior. |
+
+### `SanitizationUtils` (`io.github.rabinarayanpatra.sanitizer.core`)
+
+```java
+public final class SanitizationUtils {
+    // EXISTING (semantics preserved for POJO roots; throws IllegalArgumentException for record roots)
+    public static void apply(@Nullable Object bean);
+
+    // NEW universal entry
+    public static <T> @Nullable T applyAndReturn(@Nullable T bean);
+    public static <T> @Nullable T applyAndReturn(@Nullable T bean, TraversalSafetyChecker checker);
+}
+```
+
+### `TraversalSafetyChecker` (`io.github.rabinarayanpatra.sanitizer.core`)
+
+```java
+public interface TraversalSafetyChecker {
+    boolean shouldDescend(Object parent, java.lang.reflect.Field field);
+    TraversalSafetyChecker ALWAYS = (parent, field) -> true;
+}
+```
+
+JPA module ships a Hibernate-aware implementation; non-Spring/non-JPA users get `ALWAYS` by default.
+
+### Behavior contract for `applyAndReturn`
+
+| Input | Behavior | Returned reference |
+|---|---|---|
+| `null` | No-op | `null` |
+| POJO instance | Mutate fields in place per `FieldDescriptor` plan | Same instance |
+| Record instance | Build new instance via canonical constructor with sanitized components | New instance |
+
+### Behavior contract for legacy `apply(Object)`
+
+- POJO root: identical to existing behavior; void return.
+- Record root: throws `IllegalArgumentException` with message:
+  > `apply(Object) discards return value but record requires reassignment. Use applyAndReturn(T) for record type X.`
+- Previously threw `UnsupportedOperationException`; exception type change is intentional and documented in CHANGELOG.
+
+## Architecture
+
+### Package layout (sanitizer-core)
+
+```
+io.github.rabinarayanpatra.sanitizer.core/
+    SanitizationUtils                    // public facade
+    FieldSanitizer                       // existing
+    ConfigurableFieldSanitizer           // existing
+    SanitizerInstantiationException      // existing
+    TraversalSafetyChecker               // new, public
+
+io.github.rabinarayanpatra.sanitizer.core.traversal/   // package-private internals
+    TraversalEngine
+    ClassMetadata
+    FieldDescriptor
+```
+
+### `ClassMetadata`
+
+Built once per class, cached in `ConcurrentHashMap<Class<?>, ClassMetadata>`.
+
+```java
+final class ClassMetadata {
+    final Class<?> type;
+    final boolean isRecord;
+    final Constructor<?> canonicalCtor;        // null when !isRecord
+    final RecordComponent[] components;        // null when !isRecord
+    final List<FieldDescriptor> fields;        // walk plan, hierarchy-flattened
+}
+```
+
+For POJOs the walker iterates `fields` in declaration order, walking `getSuperclass()` chain to support `@MappedSuperclass` (existing behavior).
+
+For records the walker iterates `components` in canonical order, building an `Object[]` of arguments for `canonicalCtor.newInstance(args)`.
+
+### `FieldDescriptor`
+
+```java
+final class FieldDescriptor {
+    final Field field;                              // null for record components
+    final RecordComponent recordComponent;          // null for POJO fields
+    final List<FieldSanitizer<Object>> chain;       // ordered self-sanitizers (may be empty)
+    final boolean cascade;                          // descend flag
+    final Kind kind;                                // LEAF | POJO | RECORD | COLLECTION | MAP
+    final Class<?> elementType;                     // resolved for COLLECTION/MAP value; null otherwise
+}
+
+enum Kind { LEAF, POJO, RECORD, COLLECTION, MAP }
+```
+
+`Kind` resolution at metadata build:
+
+| Type predicate | Kind |
+|---|---|
+| `String`, primitives, boxed primitives, `UUID`, `LocalDate`, `LocalDateTime`, `Instant`, `BigDecimal`, `BigInteger`, `Enum` | `LEAF` |
+| `java.lang.Record` subclass | `RECORD` |
+| `Collection<?>` (resolved element type from `ParameterizedType`) | `COLLECTION` |
+| `Map<?,?>` (resolved value type) | `MAP` |
+| Anything else | `POJO` |
+
+If `cascade=true` on a `LEAF` field, metadata build throws `IllegalStateException` with field path and resolved type.
+
+### `TraversalEngine.walk`
+
+Single entry point invoked by the facade. Signature:
+
+```java
+@Nullable Object walk(@Nullable Object node,
+                      TraversalState state,
+                      TraversalSafetyChecker checker);
+```
+
+`TraversalState` bundles two maps allocated once per top-level `applyAndReturn` invocation:
+
+```java
+final class TraversalState {
+    final IdentityHashMap<Object, Boolean> visited;          // POJOs, collections, maps
+    final IdentityHashMap<Object, Object> reconstructedRecords; // original record -> new instance
+}
+```
+
+Algorithm:
+
+```
+if node == null
+    -> return null
+
+meta = CACHE.computeIfAbsent(node.getClass(), ClassMetadata::of)
+
+if meta.isRecord:
+    if state.reconstructedRecords.containsKey(node):
+        return state.reconstructedRecords.get(node)    // shared record ref: return same new instance
+    Object built = walkRecord(node, meta, state, checker)
+    state.reconstructedRecords.put(node, built)
+    return built
+
+if state.visited.put(node, TRUE) != null:
+    return node                                         // cycle: revisit short-circuits
+
+walkPojo(node, meta, state, checker)                    // mutates in place
+return node
+```
+
+Record sharing across graph positions is handled correctly: the second visit returns the same reconstructed instance, so two parents referencing the same original record both see the same sanitized output.
+
+`walkPojo` per `FieldDescriptor`:
+
+1. Read raw value.
+2. Apply `chain` in order; write final result to field.
+3. If `cascade && checker.shouldDescend(node, field)`:
+   - `POJO`: `walk(child, state, checker)` (in-place; ignore return)
+   - `RECORD`: `newRef = walk(child, state, checker)`; write `newRef` back to field
+   - `COLLECTION`: `walkCollection(coll, elementType, descriptor.chain, state, checker)` (may return new collection ref to write back)
+   - `MAP`: `walkMapValues(map, valueType, descriptor.chain, state, checker)` (may return new map ref)
+   - `LEAF`: unreachable (rejected at metadata build)
+
+`walkRecord`:
+
+```
+Object[] args = new Object[meta.components.length]
+for i in 0..n-1:
+    Object raw = component[i].accessor().invoke(node)
+    Object sanitized = applyChain(raw, descriptor[i].chain)
+    if descriptor[i].cascade and sanitized != null:
+        sanitized = recurseByKind(sanitized, descriptor[i], state, checker)
+    args[i] = sanitized
+return meta.canonicalCtor.newInstance(args)
+```
+
+`walkCollection`:
+
+Determine element handling from element type's `ClassMetadata`. Detect unmodifiability via a class-name allowlist (cached): `java.util.ImmutableCollections$*` (covers `List.of`, `Set.of`, `Map.of`) and `java.util.Collections$Unmodifiable*` (covers `Collections.unmodifiable*`). Probing via mutation is rejected: too many false negatives (e.g., `Arrays.asList` allows `set` but not `add`).
+
+Rules:
+
+- Element type is `RECORD` OR collection class is unmodifiable: build new `ArrayList` for `List`/`Queue`/`Deque`/other `Collection`, or `LinkedHashSet` for `Set`. Populate with sanitized elements. Return new collection (caller writes back to field).
+- Element type is `POJO`, collection is mutable: walk each element in place via `walk(elem, state, checker)`. Collection ref unchanged. Return original.
+- Element type is `LEAF` (e.g., `List<String>`) with sanitizer chain on the field: apply chain element-wise. `List`: `list.set(i, sanitized)` if identity changed. `Set`: rebuild as `LinkedHashSet` (hash may change). Return original ref if `List`, new ref if `Set`.
+
+`walkMapValues`: same logic on `map.values()`; keys never inspected.
+
+### Cycle detection
+
+`TraversalState` (one `visited` map plus one `reconstructedRecords` map) is allocated once per `applyAndReturn` invocation. Cost: two maps + entries. Revisits to the same POJO/collection/map return the existing reference without re-sanitizing. Revisits to the same original record return the previously reconstructed instance.
+
+Records cannot form record-only cycles: every record component is final, so a back-edge requires a mutable interior (collection, map, or POJO), which is cycle-checked at its own boundary.
+
+### Generic type erasure handling
+
+For `Collection` and `Map` fields, the element/value type is resolved from `Field.getGenericType()` via `ParameterizedType`. If the resolved type is a wildcard, type variable, or raw type with no concrete element class, the engine cannot determine element handling. In that case:
+
+- If the field has `cascade=true`, log WARN once per field and skip descent.
+- If the field carries a leaf sanitizer chain only, apply the chain element-wise assuming `Object` and let the existing `ClassCastException` diagnostic fire on type mismatch (preserves current behavior).
+
+### Class metadata cache
+
+`ConcurrentHashMap<Class<?>, ClassMetadata> CACHE`. Same shape as today's `SanitizationUtils.CACHE`. Class-loader leak risk acknowledged; Caffeine weak-key swap deferred to a separate ticket.
+
+## Module changes
+
+### sanitizer-core
+
+- New: `TraversalEngine`, `ClassMetadata`, `FieldDescriptor` in `core.traversal` (package-private)
+- New: `TraversalSafetyChecker` interface in `core` (public)
+- Modified: `SanitizationUtils` becomes thin facade delegating to `TraversalEngine`
+- Modified: `Sanitize` annotation adds `cascade()` attribute and makes `using()` default to `{}`
+
+### sanitizer-spring
+
+- Modified: `SanitizerModule.SanitizingDeserializer.deserialize` replaces `apply(bean); return bean` with `return SanitizationUtils.applyAndReturn(bean)`
+- No changes to `SanitizerAutoConfiguration`, `SanitizerRegistry`
+
+### sanitizer-jpa
+
+- Modified: `SanitizationEntityListener` adds optional setter `setSafetyChecker(TraversalSafetyChecker)` (defaults to `ALWAYS`)
+- Modified: `onSave` calls `SanitizationUtils.applyAndReturn(entity, checker)`
+- No new framework dependency
+
+### sanitizer-jpa-spring (NEW MODULE)
+
+- Depends on `sanitizer-jpa`, `sanitizer-spring`, `spring-boot-starter-data-jpa`
+- New: `HibernateSafetyChecker implements TraversalSafetyChecker` — delegates `shouldDescend` to `PersistenceUnitUtil.isLoaded(parent, fieldName)`
+- New: `SanitizerJpaAutoConfiguration` — registers `HibernateSafetyChecker` bean from `EntityManagerFactory.getPersistenceUnitUtil()`. JPA listeners are instantiated by the JPA provider, not Spring, so wiring uses Spring's `SpringBeanContainer` (registered via `HibernatePropertiesCustomizer` setting `hibernate.resource.beans.container`). The listener's no-arg constructor reads the safety checker through this container at bean-creation time; if no Spring context is present the listener falls back to `TraversalSafetyChecker.ALWAYS`.
+
+### Build configuration
+
+- `settings.gradle.kts`: add `include("sanitizer-jpa-spring")`
+- Root `build.gradle.kts`: existing publishing config covers the new module automatically (subprojects loop)
+- `docs/index.html`: add fourth module card linking to its Javadoc
+- `.github/workflows/publish-site.yml`: extend site assembly to copy `sanitizer-jpa-spring/build/docs/javadoc`
+
+## Error handling
+
+| Failure | Exception | Notes |
+|---|---|---|
+| `apply(record)` | `IllegalArgumentException` | Message names the record class and points to `applyAndReturn` |
+| `@Sanitize(cascade=true)` on LEAF field | `IllegalStateException` at metadata build | Message includes class.field path and resolved type |
+| Record canonical ctor throws | `InvocationTargetException` cause unwrapped and rethrown | Preserves user's compact-constructor validation message |
+| Sanitizer instantiation fails | `SanitizerInstantiationException` | Existing; unchanged |
+| Field type mismatch with sanitizer generic | `IllegalStateException` | Existing; unchanged |
+| Unmodifiable collection encountered during cascade | No exception; engine rebuilds | Silent recovery |
+| Cycle detected | No exception; visited check short-circuits | Silent recovery |
+| JPA lazy field not loaded | No exception; `shouldDescend` returns false | Silent skip |
+
+### Logging
+
+`TraversalEngine` adds an SLF4J `Logger`. Levels:
+
+- `DEBUG`: `walk class={} sanitizers={} cascade={}`
+- `TRACE`: per-field action (`sanitize field={} kind={} cascade={}`)
+
+No `INFO`/`WARN` at hot path.
+
+## Compatibility statement
+
+### Source compatibility
+
+100%. No public types removed, renamed, re-signatured, or moved. New types (`applyAndReturn`, `TraversalSafetyChecker`, `cascade` attribute) are purely additive.
+
+### Binary compatibility
+
+100%. Old `apply(Object)` retains its signature and throws-pattern (only the thrown exception type changes: `UnsupportedOperationException` -> `IllegalArgumentException` for record root inputs, which were already a failure case).
+
+### Behavioral compatibility
+
+100% for any code that does not opt in to cascade. The walker's default behavior on a POJO field without `cascade=true` is identical to the current implementation.
+
+Records that previously caused `UnsupportedOperationException` now have two valid paths:
+
+- `applyAndReturn(record)` returns a sanitized new instance (new functionality)
+- `apply(record)` throws `IllegalArgumentException` (was `UnsupportedOperationException`)
+
+Users who catch the previous exception type by name and depend on the message string must migrate. Documented in CHANGELOG migration note.
+
+### CHANGELOG entry sketch
+
+> ## [1.2.0]
+> ### Added
+> - Java records support via new `SanitizationUtils.applyAndReturn(T)` entry point
+> - Opt-in recursive traversal via `@Sanitize(cascade = true)` for nested objects, records, collections, and maps
+> - `TraversalSafetyChecker` interface for pluggable graph-walk gating
+> - New `sanitizer-jpa-spring` module providing `HibernateSafetyChecker` that skips non-initialized lazy JPA associations
+> - SLF4J logging in the traversal engine (DEBUG/TRACE)
+>
+> ### Changed
+> - `@Sanitize.using()` now defaults to `{}` so a field can opt in to cascade without supplying a self-sanitizer
+> - `SanitizationUtils.apply(record)` throws `IllegalArgumentException` (was `UnsupportedOperationException`) and recommends `applyAndReturn`
+>
+> ### Compatibility
+> - All existing POJO behavior is bit-identical. Cascade is strictly opt-in for this release.
+> - The default cascade flag will flip on in v2.0.0 along with a new `@SanitizeIgnore` opt-out annotation.
+
+## Testing strategy
+
+### sanitizer-core
+
+New tests under `src/test/java/.../core/traversal/`:
+
+- `TraversalEngineRecordTest` — single record, nested records, null components, ctor validation propagation
+- `TraversalEngineCascadeTest` — `cascade=true` on POJO, on record component, mixed POJO/record graphs, default-off backward compat assertion
+- `TraversalEngineCollectionTest` — `List<String>` leaf sanitizer, `List<Record>` rebuild, unmodifiable list rebuild, `Set` order preservation, mutable POJO list in-place mutation
+- `TraversalEngineMapTest` — values walked, keys untouched, value-record rebuild
+- `TraversalEngineCycleTest` — bidirectional POJO graph traversal terminates, label sanitized once per node
+- `TraversalEngineSafetyCheckerTest` — custom checker returning false skips descent
+- `ClassMetadataTest` — metadata built correctly for record, POJO with superclass, generic Collection element type resolution
+- `FieldDescriptorKindResolutionTest` — every Kind branch covered; `cascade=true` on LEAF throws
+
+Fixtures (test-scope only):
+
+```java
+record Address(@Sanitize(using = TrimSanitizer.class) String city,
+               @Sanitize(using = UpperCaseSanitizer.class) String country) {}
+
+record Customer(@Sanitize(using = TrimSanitizer.class) String name,
+                @Sanitize(cascade = true) Address address) {}
+
+record Order(@Sanitize(cascade = true) Customer customer,
+             @Sanitize(cascade = true) List<LineItem> items) {}
+
+record LineItem(@Sanitize(using = TrimSanitizer.class) String sku,
+                @Sanitize(using = UpperCaseSanitizer.class) String code) {}
+
+class MutableParent {
+    @Sanitize(using = TrimSanitizer.class) String name;
+    @Sanitize(cascade = true) Address embeddedRecord;
+    @Sanitize(cascade = true) List<Customer> customers;
+    @Sanitize(cascade = true) Map<String, LineItem> items;
+}
+
+class CyclicNode {
+    @Sanitize(using = TrimSanitizer.class) String label;
+    @Sanitize(cascade = true) CyclicNode next;
+}
+```
+
+### Backward-compat regression suite
+
+- All 18 existing builtin sanitizer tests pass unchanged
+- Existing `SanitizationUtilsTest` and `ConfigurableFieldSanitizerTest` scenarios pass unchanged
+- New explicit test: a POJO with a nested annotated field but without `cascade=true` leaves the nested field untouched after `apply(root)`
+
+### sanitizer-jpa
+
+- `HibernateSafetyCheckerTest` — Mockito-backed `PersistenceUnitUtil`; assert `shouldDescend` returns false for unloaded field name and true for loaded
+- Integration test with H2 + Hibernate: bidirectional `@OneToMany`/`@ManyToOne` entity, persist parent with un-fetched children, assert no `LazyInitializationException` and child not sanitized
+
+### sanitizer-jpa-spring
+
+- `SanitizerJpaAutoConfigurationTest` — verify `HibernateSafetyChecker` bean exposed and wired into `SanitizationEntityListener`
+- End-to-end `@DataJpaTest` slice persisting a sanitized entity via the listener
+
+### sanitizer-spring
+
+- Existing `SanitizerModuleIntegrationTest` extended with a record DTO case
+- New test: nested record DTO with `cascade=true` round-trips through Jackson
+
+### Coverage target
+
+Aggregated JaCoCo coverage stays at or above the current floor (98%).
+
+## Deferred items
+
+| Item | Target |
+|---|---|
+| Default cascade flips on, `@SanitizeIgnore` introduced | v2.0.0 |
+| Caffeine weak-key `ClassMetadata` cache | Separate ticket |
+| jqwik property-based tests for sanitizer purity | Separate ticket |
+| Bean Validation `ConstraintValidator` adapter | Separate ticket |
+| Spring Boot 4 / Jackson 3 BOM upgrade | Separate ticket |
+| GraalVM `RuntimeHints` registration for AOT/native | Separate ticket |
+
+## Open questions
+
+None. All design decisions resolved during brainstorming.

--- a/sanitizer-core/build.gradle.kts
+++ b/sanitizer-core/build.gradle.kts
@@ -1,3 +1,5 @@
 dependencies {
+    api("org.slf4j:slf4j-api")
     testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.slf4j:slf4j-simple")
 }

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/annotation/Sanitize.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/annotation/Sanitize.java
@@ -10,29 +10,13 @@ import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
 
 /**
  * Apply one or more {@link FieldSanitizer} implementations to this field, in
- * the order listed. Sanitizers are applied in array order, so
- * {@code @Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})}
- * guarantees trim-then-lowercase.
+ * the order listed, and/or descend into this field's object graph.
  *
  * <p>
  * This annotation is {@link Repeatable}, so multiple {@code @Sanitize}
  * annotations can be stacked on the same field. Sanitizers are applied in
- * declaration order.
- *
- * <p>
- * Example:
- *
- * <pre>
- * {
- * 	&#64;code
- * 	public class Person {
- * 		&#64;Sanitize(using = TrimSanitizer.class)
- * 		&#64;Sanitize(using = CollapseWhitespaceSanitizer.class)
- * 		&#64;Sanitize(using = LowerCaseSanitizer.class)
- * 		private String fullName;
- * 	}
- * }
- * </pre>
+ * declaration order. When {@link #cascade()} is true on any stacked instance,
+ * the engine descends into the field's value after self-sanitizers run.
  *
  * @since 1.0.0
  */
@@ -41,12 +25,14 @@ import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
 @Target(ElementType.FIELD)
 public @interface Sanitize {
 	/**
-	 * The ordered list of FieldSanitizer implementations to apply.
+	 * The ordered list of FieldSanitizer implementations to apply to this field's
+	 * value. May be empty when the annotation is used solely to opt into
+	 * {@link #cascade() cascade}.
 	 *
-	 * @return the sanitizer classes
+	 * @return the sanitizer classes, possibly empty
 	 */
 	@SuppressWarnings("java:S1452")
-	Class<? extends FieldSanitizer<?>>[] using();
+	Class<? extends FieldSanitizer<?>>[] using() default {};
 
 	/**
 	 * Optional comma-separated {@code key=value} configuration parameters passed to
@@ -61,4 +47,17 @@ public @interface Sanitize {
 	 * @since 1.1.0
 	 */
 	String params() default "";
+
+	/**
+	 * When true, the traversal engine descends into this field's value after any
+	 * self-sanitizers run. Supported on fields whose static type is a POJO, record,
+	 * {@link java.util.Collection}, or {@link java.util.Map}. Applying
+	 * {@code cascade=true} to a leaf type (e.g. {@code String}, primitive, boxed
+	 * primitive, {@code UUID}, JSR-310 temporal, {@code BigDecimal},
+	 * {@code BigInteger}, {@code Enum}) is rejected at metadata-build time.
+	 *
+	 * @return true to descend into this field's object graph
+	 * @since 1.2.0
+	 */
+	boolean cascade() default false;
 }

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/FieldSanitizer.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/FieldSanitizer.java
@@ -19,4 +19,19 @@ public interface FieldSanitizer<T> {
 	 */
 	@Nullable
 	T sanitize(@Nullable T input);
+
+	/**
+	 * Returns this sanitizer typed as {@code FieldSanitizer<Object>}. The cast is
+	 * safe at runtime because the traversal engine routes each sanitizer only to
+	 * fields whose declared type matches the sanitizer's generic parameter; a
+	 * {@code ClassCastException} thrown by {@code sanitize} is caught and rewrapped
+	 * with a descriptive {@code IllegalStateException} by the engine.
+	 *
+	 * @return this sanitizer as an Object-typed sanitizer
+	 * @since 1.2.0
+	 */
+	@SuppressWarnings("unchecked")
+	default FieldSanitizer<Object> asObjectSanitizer() {
+		return (FieldSanitizer<Object>) this;
+	}
 }

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtils.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtils.java
@@ -1,121 +1,42 @@
 package io.github.rabinarayanpatra.sanitizer.core;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.jspecify.annotations.Nullable;
 
 import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngine;
+import io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalState;
 
 /**
- * Utility class that applies {@link FieldSanitizer} logic to bean fields
- * annotated with {@link Sanitize}.
+ * Public facade for applying {@link Sanitize} annotations to bean fields. All
+ * traversal logic lives in
+ * {@link io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngine};
+ * this class is a thin entry point.
  *
  * @since 1.0.0
  */
 public final class SanitizationUtils {
 
-	private static final Map<Class<?>, List<Holder>> CACHE = new ConcurrentHashMap<>();
-
 	private SanitizationUtils() {
 	}
 
 	/**
-	 * Applies all configured sanitizers to the fields of the given bean that are
-	 * annotated with {@link Sanitize}.
+	 * Applies sanitizers in place to a POJO. Throws for record inputs because
+	 * record components cannot be mutated and the void return would discard the
+	 * reconstructed instance. Use {@link #applyAndReturn(Object)} for records.
 	 *
 	 * @param bean
-	 *            the object whose fields should be sanitized
+	 *            the POJO whose fields should be sanitized; may be null
+	 * @throws IllegalArgumentException
+	 *             when {@code bean} is a {@link Record} instance
 	 */
 	public static void apply(final @Nullable Object bean) {
 		if (bean == null) {
 			return;
 		}
-
-		final Class<?> cls = bean.getClass();
-		final List<Holder> holders = CACHE.computeIfAbsent(cls, SanitizationUtils::inspect);
-
-		for (final Holder h : holders) {
-			try {
-				final Field f = h.field;
-				final Object raw = f.get(bean);
-				if (raw == null) {
-					final Object clean = h.sanitizer.sanitize(null);
-					if (clean != null) {
-						f.set(bean, clean);
-					}
-					continue;
-				}
-				final Object clean = h.sanitizer.sanitize(raw);
-				f.set(bean, clean);
-			} catch (final IllegalAccessException e) {
-				throw new IllegalStateException(
-						"Cannot access field '" + h.field.getName() + "' on " + bean.getClass().getName()
-								+ ". This may occur with Java records, JPMS strongly-encapsulated fields, "
-								+ "or final fields. Ensure the field is mutable and accessible.",
-						e);
-			} catch (final ClassCastException e) {
-				throw new IllegalStateException("Type mismatch: sanitizer " + h.sanitizer.getClass().getName()
-						+ " is not compatible with field '" + h.field.getName() + "' of type "
-						+ h.field.getType().getName() + " on " + bean.getClass().getName()
-						+ ". Ensure the sanitizer's generic type matches the field type.", e);
-			}
+		if (bean.getClass().isRecord()) {
+			throw new IllegalArgumentException("apply(Object) discards return value but record requires reassignment. "
+					+ "Use applyAndReturn(T) for record type " + bean.getClass().getName() + ".");
 		}
-	}
-
-	/**
-	 * Inspects the class hierarchy to find fields annotated with {@link Sanitize}
-	 * and builds sanitizer handlers. Walks superclasses to support
-	 * {@code @MappedSuperclass} and other inheritance patterns.
-	 */
-	private static List<Holder> inspect(final Class<?> cls) {
-		if (cls.isRecord()) {
-			throw new UnsupportedOperationException("@Sanitize is not supported on Java records (" + cls.getName()
-					+ "). Records have final fields that cannot be modified via reflection. "
-					+ "Use a mutable DTO or POJO instead, and copy values into the record after sanitization.");
-		}
-
-		final List<Holder> list = new ArrayList<>();
-
-		Class<?> current = cls;
-		while (current != null && current != Object.class) {
-			for (final Field field : current.getDeclaredFields()) {
-				final Sanitize[] annotations = field.getAnnotationsByType(Sanitize.class);
-				if (annotations.length == 0) {
-					continue;
-				}
-
-				field.setAccessible(true);
-				for (final Sanitize ann : annotations) {
-					for (final Class<? extends FieldSanitizer<?>> sanitizerClass : ann.using()) {
-						try {
-							@SuppressWarnings("unchecked")
-							final FieldSanitizer<Object> sanitizer = (FieldSanitizer<Object>) sanitizerClass
-									.getDeclaredConstructor().newInstance();
-							if (sanitizer instanceof ConfigurableFieldSanitizer<?> configurable
-									&& !ann.params().isBlank()) {
-								configurable.configure(ConfigurableFieldSanitizer.parseParams(ann.params()));
-							}
-							list.add(new Holder(field, sanitizer));
-						} catch (final ReflectiveOperationException e) {
-							throw new SanitizerInstantiationException(
-									"Cannot instantiate sanitizer " + sanitizerClass.getName(), e);
-						}
-					}
-				}
-			}
-			current = current.getSuperclass();
-		}
-
-		return list;
-	}
-
-	/**
-	 * Binds a {@link Field} with its corresponding {@link FieldSanitizer}.
-	 */
-	private record Holder(Field field, FieldSanitizer<Object> sanitizer) {
+		TraversalEngine.walk(bean, new TraversalState(), TraversalSafetyChecker.ALWAYS);
 	}
 }

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtils.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtils.java
@@ -4,7 +4,6 @@ import org.jspecify.annotations.Nullable;
 
 import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
 import io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngine;
-import io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalState;
 
 /**
  * Public facade for applying {@link Sanitize} annotations to bean fields. All
@@ -37,6 +36,6 @@ public final class SanitizationUtils {
 			throw new IllegalArgumentException("apply(Object) discards return value but record requires reassignment. "
 					+ "Use applyAndReturn(T) for record type " + bean.getClass().getName() + ".");
 		}
-		TraversalEngine.walk(bean, new TraversalState(), TraversalSafetyChecker.ALWAYS);
+		TraversalEngine.walk(bean, TraversalSafetyChecker.ALWAYS);
 	}
 }

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtils.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtils.java
@@ -6,10 +6,7 @@ import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
 import io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngine;
 
 /**
- * Public facade for applying {@link Sanitize} annotations to bean fields. All
- * traversal logic lives in
- * {@link io.github.rabinarayanpatra.sanitizer.core.traversal.TraversalEngine};
- * this class is a thin entry point.
+ * Public facade for applying {@link Sanitize} annotations to bean fields.
  *
  * @since 1.0.0
  */
@@ -37,5 +34,43 @@ public final class SanitizationUtils {
 					+ "Use applyAndReturn(T) for record type " + bean.getClass().getName() + ".");
 		}
 		TraversalEngine.walk(bean, TraversalSafetyChecker.ALWAYS);
+	}
+
+	/**
+	 * Universal sanitization entry point. POJO inputs are mutated in place and the
+	 * same reference is returned; record inputs are reconstructed via their
+	 * canonical constructor and a new instance is returned.
+	 *
+	 * @param bean
+	 *            the bean to sanitize; may be null
+	 * @param <T>
+	 *            the static type of the bean
+	 * @return the sanitized bean (same ref for POJOs, new instance for records)
+	 * @since 1.2.0
+	 */
+	public static <T> @Nullable T applyAndReturn(final @Nullable T bean) {
+		return applyAndReturn(bean, TraversalSafetyChecker.ALWAYS);
+	}
+
+	/**
+	 * Universal sanitization entry point with a custom safety checker. See
+	 * {@link #applyAndReturn(Object)}.
+	 *
+	 * @param bean
+	 *            the bean to sanitize; may be null
+	 * @param checker
+	 *            the safety checker that gates descent into individual fields; must
+	 *            not be null
+	 * @param <T>
+	 *            the static type of the bean
+	 * @return the sanitized bean (same ref for POJOs, new instance for records)
+	 * @since 1.2.0
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> @Nullable T applyAndReturn(final @Nullable T bean, final TraversalSafetyChecker checker) {
+		if (bean == null) {
+			return null;
+		}
+		return (T) TraversalEngine.walk(bean, checker);
 	}
 }

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/TraversalSafetyChecker.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/TraversalSafetyChecker.java
@@ -1,0 +1,33 @@
+package io.github.rabinarayanpatra.sanitizer.core;
+
+import java.lang.reflect.Field;
+
+/**
+ * Pluggable gate that lets callers decide whether the traversal engine may
+ * descend into a given field of a parent object. Used to avoid touching
+ * non-initialized JPA lazy associations or other contexts where reading a field
+ * is expensive or unsafe.
+ *
+ * @since 1.2.0
+ */
+@FunctionalInterface
+public interface TraversalSafetyChecker {
+
+	/**
+	 * Returns true when the engine may read and recurse into {@code field} on
+	 * {@code parent}.
+	 *
+	 * @param parent
+	 *            the bean currently being walked
+	 * @param field
+	 *            the field about to be descended into
+	 * @return true to allow descent; false to skip this field
+	 */
+	boolean shouldDescend(Object parent, Field field);
+
+	/**
+	 * No-op checker that always permits descent. Default used by
+	 * {@code sanitizer-core} when callers do not supply a custom checker.
+	 */
+	TraversalSafetyChecker ALWAYS = (parent, field) -> true;
+}

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadata.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadata.java
@@ -101,6 +101,10 @@ final class ClassMetadata {
 		}
 		final List<FieldDescriptor> descriptors = new ArrayList<>(components.length);
 		for (final RecordComponent rc : components) {
+			// Records declared in another module/package require setAccessible on
+			// their synthetic accessors so reflective invocation succeeds from the
+			// engine's package.
+			rc.getAccessor().setAccessible(true);
 			descriptors.add(describeRecordComponent(cls, rc));
 		}
 		return new ClassMetadata(cls, true, canonical, components, descriptors);

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadata.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadata.java
@@ -1,0 +1,240 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.RecordComponent;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jspecify.annotations.Nullable;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.core.ConfigurableFieldSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizerInstantiationException;
+
+/**
+ * Per-class compiled plan: ordered list of {@link FieldDescriptor} plus record
+ * metadata when applicable. Constructed once per class and cached in a static
+ * {@code ConcurrentHashMap}.
+ */
+final class ClassMetadata {
+
+	private static final Map<Class<?>, ClassMetadata> CACHE = new ConcurrentHashMap<>();
+
+	private static final Set<Class<?>> LEAF_TYPES = Set.of(String.class, Boolean.class, Byte.class, Character.class,
+			Short.class, Integer.class, Long.class, Float.class, Double.class, UUID.class, LocalDate.class,
+			LocalDateTime.class, Instant.class, BigDecimal.class, BigInteger.class);
+
+	private final Class<?> type;
+	private final boolean isRecord;
+	private final @Nullable Constructor<?> canonicalCtor;
+	private final RecordComponent @Nullable [] components;
+	private final List<FieldDescriptor> fields;
+
+	private ClassMetadata(final Class<?> type, final boolean isRecord, final @Nullable Constructor<?> canonicalCtor,
+			final RecordComponent @Nullable [] components, final List<FieldDescriptor> fields) {
+		this.type = type;
+		this.isRecord = isRecord;
+		this.canonicalCtor = canonicalCtor;
+		this.components = components;
+		this.fields = List.copyOf(fields);
+	}
+
+	static ClassMetadata of(final Class<?> cls) {
+		return CACHE.computeIfAbsent(cls, ClassMetadata::build);
+	}
+
+	Class<?> type() {
+		return type;
+	}
+
+	boolean isRecord() {
+		return isRecord;
+	}
+
+	@Nullable
+	Constructor<?> canonicalCtor() {
+		return canonicalCtor;
+	}
+
+	RecordComponent @Nullable [] components() {
+		return components;
+	}
+
+	List<FieldDescriptor> fields() {
+		return fields;
+	}
+
+	private static ClassMetadata build(final Class<?> cls) {
+		if (cls.isRecord()) {
+			return buildRecord(cls);
+		}
+		return buildPojo(cls);
+	}
+
+	private static ClassMetadata buildRecord(final Class<?> cls) {
+		final RecordComponent[] components = cls.getRecordComponents();
+		final Class<?>[] paramTypes = new Class<?>[components.length];
+		for (int i = 0; i < components.length; i++) {
+			paramTypes[i] = components[i].getType();
+		}
+		final Constructor<?> canonical;
+		try {
+			canonical = cls.getDeclaredConstructor(paramTypes);
+			canonical.setAccessible(true);
+		} catch (final NoSuchMethodException e) {
+			throw new SanitizerInstantiationException("Cannot find canonical constructor for record " + cls.getName(),
+					e);
+		}
+		final List<FieldDescriptor> descriptors = new ArrayList<>(components.length);
+		for (final RecordComponent rc : components) {
+			descriptors.add(describeRecordComponent(cls, rc));
+		}
+		return new ClassMetadata(cls, true, canonical, components, descriptors);
+	}
+
+	private static FieldDescriptor describeRecordComponent(final Class<?> owner, final RecordComponent rc) {
+		final Sanitize[] anns = readRecordComponentAnnotations(owner, rc);
+		final List<FieldSanitizer<Object>> chain = buildChain(anns);
+		final boolean cascade = anyCascade(anns);
+		validateMeaningful(owner, rc.getName(), chain, cascade);
+		final Class<?> declared = rc.getType();
+		final Kind kind = resolveKind(declared);
+		validateCascadeKind(owner, rc.getName(), kind, cascade);
+		final Class<?> elementType = resolveElementType(rc.getGenericType(), kind);
+		return FieldDescriptor.forRecordComponent(rc, chain, cascade, kind, elementType);
+	}
+
+	private static Sanitize[] readRecordComponentAnnotations(final Class<?> owner, final RecordComponent rc) {
+		final Sanitize[] direct = rc.getAnnotationsByType(Sanitize.class);
+		if (direct.length > 0) {
+			return direct;
+		}
+		// @Sanitize is @Target(FIELD), so annotations on a record component propagate
+		// to the backing field rather than being visible via RecordComponent.
+		try {
+			final Field backing = owner.getDeclaredField(rc.getName());
+			return backing.getAnnotationsByType(Sanitize.class);
+		} catch (final NoSuchFieldException e) {
+			return new Sanitize[0];
+		}
+	}
+
+	private static ClassMetadata buildPojo(final Class<?> cls) {
+		final List<FieldDescriptor> descriptors = new ArrayList<>();
+		Class<?> current = cls;
+		while (current != null && current != Object.class) {
+			for (final Field field : current.getDeclaredFields()) {
+				final Sanitize[] anns = field.getAnnotationsByType(Sanitize.class);
+				if (anns.length == 0) {
+					continue;
+				}
+				field.setAccessible(true);
+				final List<FieldSanitizer<Object>> chain = buildChain(anns);
+				final boolean cascade = anyCascade(anns);
+				validateMeaningful(cls, field.getName(), chain, cascade);
+				final Kind kind = resolveKind(field.getType());
+				validateCascadeKind(cls, field.getName(), kind, cascade);
+				final Class<?> elementType = resolveElementType(field.getGenericType(), kind);
+				descriptors.add(FieldDescriptor.forPojoField(field, chain, cascade, kind, elementType));
+			}
+			current = current.getSuperclass();
+		}
+		return new ClassMetadata(cls, false, null, null, descriptors);
+	}
+
+	private static List<FieldSanitizer<Object>> buildChain(final Sanitize[] anns) {
+		final List<FieldSanitizer<Object>> chain = new ArrayList<>();
+		for (final Sanitize ann : anns) {
+			for (final Class<? extends FieldSanitizer<?>> sanitizerClass : ann.using()) {
+				final FieldSanitizer<?> sanitizer;
+				try {
+					sanitizer = sanitizerClass.getDeclaredConstructor().newInstance();
+				} catch (final ReflectiveOperationException e) {
+					throw new SanitizerInstantiationException(
+							"Cannot instantiate sanitizer " + sanitizerClass.getName(), e);
+				}
+				if (sanitizer instanceof ConfigurableFieldSanitizer<?> configurable && !ann.params().isBlank()) {
+					configurable.configure(ConfigurableFieldSanitizer.parseParams(ann.params()));
+				}
+				chain.add(sanitizer.asObjectSanitizer());
+			}
+		}
+		return chain;
+	}
+
+	private static boolean anyCascade(final Sanitize[] anns) {
+		for (final Sanitize ann : anns) {
+			if (ann.cascade()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static void validateMeaningful(final Class<?> owner, final String name,
+			final List<FieldSanitizer<Object>> chain, final boolean cascade) {
+		if (chain.isEmpty() && !cascade) {
+			throw new IllegalStateException("@Sanitize on " + owner.getName() + "." + name
+					+ " has no sanitizer and cascade=false. Either supply using={...} or set cascade=true.");
+		}
+	}
+
+	private static void validateCascadeKind(final Class<?> owner, final String name, final Kind kind,
+			final boolean cascade) {
+		if (cascade && kind == Kind.LEAF) {
+			throw new IllegalStateException("@Sanitize(cascade=true) on " + owner.getName() + "." + name
+					+ " resolves to a LEAF type. Cascade requires POJO, RECORD, COLLECTION, or MAP.");
+		}
+	}
+
+	private static Kind resolveKind(final Class<?> declared) {
+		if (declared.isPrimitive() || LEAF_TYPES.contains(declared) || declared.isEnum()) {
+			return Kind.LEAF;
+		}
+		if (declared.isRecord()) {
+			return Kind.RECORD;
+		}
+		if (Collection.class.isAssignableFrom(declared)) {
+			return Kind.COLLECTION;
+		}
+		if (Map.class.isAssignableFrom(declared)) {
+			return Kind.MAP;
+		}
+		return Kind.POJO;
+	}
+
+	private static @Nullable Class<?> resolveElementType(final Type genericType, final Kind kind) {
+		if (kind != Kind.COLLECTION && kind != Kind.MAP) {
+			return null;
+		}
+		if (!(genericType instanceof ParameterizedType pt)) {
+			return null;
+		}
+		final Type[] args = pt.getActualTypeArguments();
+		if (args.length == 0) {
+			return null;
+		}
+		final Type target = (kind == Kind.MAP && args.length > 1) ? args[1] : args[0];
+		if (target instanceof Class<?> cls) {
+			return cls;
+		}
+		if (target instanceof ParameterizedType nested && nested.getRawType() instanceof Class<?> raw) {
+			return raw;
+		}
+		return null;
+	}
+}

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadata.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadata.java
@@ -110,11 +110,16 @@ final class ClassMetadata {
 		final Sanitize[] anns = readRecordComponentAnnotations(owner, rc);
 		final List<FieldSanitizer<Object>> chain = buildChain(anns);
 		final boolean cascade = anyCascade(anns);
-		validateMeaningful(owner, rc.getName(), chain, cascade);
 		final Class<?> declared = rc.getType();
 		final Kind kind = resolveKind(declared);
-		validateCascadeKind(owner, rc.getName(), kind, cascade);
 		final Class<?> elementType = resolveElementType(rc.getGenericType(), kind);
+		if (anns.length == 0) {
+			// Unannotated record components produce pass-through descriptors so
+			// canonical-constructor reconstruction can still copy the raw value.
+			return FieldDescriptor.forRecordComponent(rc, chain, cascade, kind, elementType);
+		}
+		validateMeaningful(owner, rc.getName(), chain, cascade);
+		validateCascadeKind(owner, rc.getName(), kind, cascade);
 		return FieldDescriptor.forRecordComponent(rc, chain, cascade, kind, elementType);
 	}
 

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/CollectionWalker.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/CollectionWalker.java
@@ -1,0 +1,121 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+/** Cascade descent into {@link Collection} fields. */
+final class CollectionWalker {
+
+	private static final Logger LOG = LoggerFactory.getLogger(CollectionWalker.class);
+
+	private CollectionWalker() {
+	}
+
+	/**
+	 * Walks a collection. Returns the same reference when elements are mutated in
+	 * place; returns a new collection when the original is unmodifiable or when
+	 * elements are records (immutable).
+	 */
+	@SuppressWarnings("unchecked")
+	static Collection<?> walk(final Collection<?> coll, final @Nullable Class<?> elementType,
+			final List<FieldSanitizer<Object>> chain, final TraversalState state,
+			final TraversalSafetyChecker checker) {
+		if (elementType == null) {
+			LOG.warn("collection field has no resolvable element type; skipping cascade");
+			return coll;
+		}
+		final Kind elementKind = kindOf(elementType);
+		final boolean isUnmodifiable = isUnmodifiable(coll);
+		final boolean rebuild = isUnmodifiable || elementKind == Kind.RECORD;
+
+		if (rebuild) {
+			return rebuild(coll, elementKind, chain, state, checker);
+		}
+		// Mutable in-place path
+		if (coll instanceof List<?>) {
+			walkListInPlace((List<Object>) coll, elementKind, chain, state, checker);
+			return coll;
+		}
+		if (coll instanceof Set<?>) {
+			// Sets: rebuild even when mutable, because hash codes may change for
+			// records and leaf-sanitized strings.
+			return rebuild(coll, elementKind, chain, state, checker);
+		}
+		// Other Collection: rebuild as ArrayList
+		return rebuild(coll, elementKind, chain, state, checker);
+	}
+
+	private static void walkListInPlace(final List<Object> list, final Kind elementKind,
+			final List<FieldSanitizer<Object>> chain, final TraversalState state,
+			final TraversalSafetyChecker checker) {
+		for (int i = 0; i < list.size(); i++) {
+			final Object raw = list.get(i);
+			final Object processed = processElement(raw, elementKind, chain, state, checker);
+			if (processed != raw) {
+				list.set(i, processed);
+			}
+		}
+	}
+
+	private static Collection<?> rebuild(final Collection<?> source, final Kind elementKind,
+			final List<FieldSanitizer<Object>> chain, final TraversalState state,
+			final TraversalSafetyChecker checker) {
+		final Collection<Object> target = source instanceof Set<?>
+				? new LinkedHashSet<>(source.size())
+				: new ArrayList<>(source.size());
+		for (final Object raw : source) {
+			target.add(processElement(raw, elementKind, chain, state, checker));
+		}
+		return target;
+	}
+
+	private static @Nullable Object processElement(final @Nullable Object raw, final Kind elementKind,
+			final List<FieldSanitizer<Object>> chain, final TraversalState state,
+			final TraversalSafetyChecker checker) {
+		if (raw == null) {
+			return null;
+		}
+		Object current = raw;
+		for (final FieldSanitizer<Object> s : chain) {
+			current = s.sanitize(current);
+		}
+		if (elementKind == Kind.POJO || elementKind == Kind.RECORD) {
+			final Object after = TraversalEngine.walk(current, state, checker);
+			current = after == null ? current : after;
+		}
+		return current;
+	}
+
+	private static Kind kindOf(final Class<?> elementType) {
+		if (elementType.isRecord()) {
+			return Kind.RECORD;
+		}
+		if (Collection.class.isAssignableFrom(elementType) || java.util.Map.class.isAssignableFrom(elementType)) {
+			// Nested collections within collections are out of scope for v1.2.0;
+			// treat as POJO so the engine descends into the wrapper.
+			return Kind.POJO;
+		}
+		if (elementType.isPrimitive() || elementType.isEnum() || elementType == String.class
+				|| elementType == Integer.class || elementType == Long.class || elementType == Boolean.class
+				|| elementType == java.util.UUID.class || elementType == java.time.Instant.class) {
+			return Kind.LEAF;
+		}
+		return Kind.POJO;
+	}
+
+	private static boolean isUnmodifiable(final Collection<?> coll) {
+		final String name = coll.getClass().getName();
+		return name.startsWith("java.util.ImmutableCollections$")
+				|| name.startsWith("java.util.Collections$Unmodifiable");
+	}
+}

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/FieldDescriptor.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/FieldDescriptor.java
@@ -1,0 +1,27 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.RecordComponent;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+
+/**
+ * Compiled descriptor for a single field (POJO) or record component. Built once
+ * per class by {@link ClassMetadata} and reused on every traversal.
+ */
+record FieldDescriptor(@Nullable Field field, @Nullable RecordComponent recordComponent,
+		List<FieldSanitizer<Object>> chain, boolean cascade, Kind kind, @Nullable Class<?> elementType) {
+
+	static FieldDescriptor forPojoField(final Field field, final List<FieldSanitizer<Object>> chain,
+			final boolean cascade, final Kind kind, final @Nullable Class<?> elementType) {
+		return new FieldDescriptor(field, null, chain, cascade, kind, elementType);
+	}
+
+	static FieldDescriptor forRecordComponent(final RecordComponent component, final List<FieldSanitizer<Object>> chain,
+			final boolean cascade, final Kind kind, final @Nullable Class<?> elementType) {
+		return new FieldDescriptor(null, component, chain, cascade, kind, elementType);
+	}
+}

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/Kind.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/Kind.java
@@ -1,0 +1,21 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+/**
+ * Classification of a field's declared type that drives traversal behavior.
+ */
+enum Kind {
+	/**
+	 * Strings, primitives/boxed, UUID, JSR-310 temporals, BigDecimal/Integer, Enum.
+	 */
+	LEAF,
+	/**
+	 * Plain mutable Java object (any class that is not LEAF/RECORD/COLLECTION/MAP).
+	 */
+	POJO,
+	/** Subclass of {@link java.lang.Record}. */
+	RECORD,
+	/** Subtype of {@link java.util.Collection}. */
+	COLLECTION,
+	/** Subtype of {@link java.util.Map}. */
+	MAP
+}

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/MapWalker.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/MapWalker.java
@@ -1,0 +1,65 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+/** Cascade descent into {@link Map} fields. Keys are never inspected. */
+final class MapWalker {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MapWalker.class);
+
+	private MapWalker() {
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	static Map<?, ?> walk(final Map<?, ?> map, final @Nullable Class<?> valueType,
+			final List<FieldSanitizer<Object>> chain, final TraversalState state,
+			final TraversalSafetyChecker checker) {
+		if (valueType == null) {
+			LOG.warn("map field has no resolvable value type; skipping cascade");
+			return map;
+		}
+		final boolean rebuild = isUnmodifiable(map);
+		if (rebuild) {
+			final Map<Object, Object> target = new LinkedHashMap<>(map.size());
+			for (final Map.Entry<?, ?> e : map.entrySet()) {
+				target.put(e.getKey(), processValue(e.getValue(), valueType, chain, state, checker));
+			}
+			return target;
+		}
+		// Mutable: walk values in place via replaceAll so the map ref is preserved.
+		((Map) map).replaceAll((k, v) -> processValue(v, valueType, chain, state, checker));
+		return map;
+	}
+
+	private static @Nullable Object processValue(final @Nullable Object raw, final Class<?> valueType,
+			final List<FieldSanitizer<Object>> chain, final TraversalState state,
+			final TraversalSafetyChecker checker) {
+		if (raw == null) {
+			return null;
+		}
+		Object current = raw;
+		for (final FieldSanitizer<Object> s : chain) {
+			current = s.sanitize(current);
+		}
+		if (valueType.isRecord() || !(valueType.isPrimitive() || valueType == String.class)) {
+			final Object after = TraversalEngine.walk(current, state, checker);
+			current = after == null ? current : after;
+		}
+		return current;
+	}
+
+	private static boolean isUnmodifiable(final Map<?, ?> map) {
+		final String name = map.getClass().getName();
+		return name.startsWith("java.util.ImmutableCollections$")
+				|| name.startsWith("java.util.Collections$Unmodifiable");
+	}
+}

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java
@@ -40,18 +40,19 @@ public final class TraversalEngine {
 			if (cached != null) {
 				return cached;
 			}
-			final Object built = walkRecord(node, meta);
+			final Object built = walkRecord(node, meta, state, checker);
 			state.storeReconstructed(node, built);
 			return built;
 		}
 		if (!state.markVisited(node)) {
 			return node;
 		}
-		walkPojo(node, meta);
+		walkPojo(node, meta, state, checker);
 		return node;
 	}
 
-	private static Object walkRecord(final Object node, final ClassMetadata meta) {
+	private static Object walkRecord(final Object node, final ClassMetadata meta, final TraversalState state,
+			final TraversalSafetyChecker checker) {
 		LOG.debug("walk record class={} components={}", node.getClass().getName(), meta.fields().size());
 		final RecordComponent[] components = meta.components();
 		final Object[] args = new Object[components.length];
@@ -60,7 +61,11 @@ public final class TraversalEngine {
 			final FieldDescriptor d = meta.fields().get(i);
 			try {
 				final Object raw = rc.getAccessor().invoke(node);
-				args[i] = applyChain(raw, d.chain());
+				Object current = applyChain(raw, d.chain());
+				if (d.cascade() && current != null) {
+					current = descendByKind(current, d, state, checker);
+				}
+				args[i] = current;
 			} catch (final IllegalAccessException e) {
 				throw new IllegalStateException(
 						"Cannot invoke accessor for component '" + rc.getName() + "' on " + node.getClass().getName(),
@@ -82,7 +87,8 @@ public final class TraversalEngine {
 		}
 	}
 
-	private static void walkPojo(final Object node, final ClassMetadata meta) {
+	private static void walkPojo(final Object node, final ClassMetadata meta, final TraversalState state,
+			final TraversalSafetyChecker checker) {
 		LOG.debug("walk pojo class={} fields={}", node.getClass().getName(), meta.fields().size());
 		for (final FieldDescriptor d : meta.fields()) {
 			final Field field = d.field();
@@ -93,6 +99,12 @@ public final class TraversalEngine {
 				final Object raw = field.get(node);
 				final Object sanitized = applyChain(raw, d.chain());
 				writeBackIfChanged(node, field, raw, sanitized);
+				if (d.cascade() && sanitized != null && checker.shouldDescend(node, field)) {
+					final Object after = descendByKind(sanitized, d, state, checker);
+					if (after != sanitized) {
+						field.set(node, after);
+					}
+				}
 			} catch (final IllegalAccessException e) {
 				throw new IllegalStateException("Cannot access field '" + field.getName() + "' on "
 						+ node.getClass().getName() + ". Ensure the field is mutable and accessible.", e);
@@ -103,6 +115,28 @@ public final class TraversalEngine {
 						e);
 			}
 		}
+	}
+
+	private static Object descendByKind(final Object child, final FieldDescriptor d, final TraversalState state,
+			final TraversalSafetyChecker checker) {
+		switch (d.kind()) {
+			case POJO -> {
+				walk(child, state, checker);
+				return child;
+			}
+			case RECORD -> {
+				final Object replaced = walk(child, state, checker);
+				return replaced == null ? child : replaced;
+			}
+			case COLLECTION, MAP -> {
+				// Implemented in Tasks 11 and 12.
+				LOG.warn("cascade into {} not yet implemented; skipping", d.kind());
+				return child;
+			}
+			case LEAF -> throw new IllegalStateException("Internal error: cascade descent reached LEAF for "
+					+ (d.field() != null ? d.field().getName() : d.recordComponent().getName()));
+		}
+		return child;
 	}
 
 	private static @Nullable Object applyChain(final @Nullable Object raw, final List<FieldSanitizer<Object>> chain) {

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java
@@ -11,8 +11,8 @@ import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
 
 /**
  * Recursive walker that applies sanitizers and (optionally) descends into a
- * bean's object graph. Entry point:
- * {@link #walk(Object, TraversalState, TraversalSafetyChecker)}.
+ * bean's object graph. Public entry point:
+ * {@link #walk(Object, TraversalSafetyChecker)}.
  */
 public final class TraversalEngine {
 
@@ -21,7 +21,11 @@ public final class TraversalEngine {
 	private TraversalEngine() {
 	}
 
-	public static @Nullable Object walk(final @Nullable Object node, final TraversalState state,
+	public static @Nullable Object walk(final @Nullable Object node, final TraversalSafetyChecker checker) {
+		return walk(node, new TraversalState(), checker);
+	}
+
+	static @Nullable Object walk(final @Nullable Object node, final TraversalState state,
 			final TraversalSafetyChecker checker) {
 		if (node == null) {
 			return null;

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java
@@ -1,12 +1,16 @@
 package io.github.rabinarayanpatra.sanitizer.core.traversal;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.RecordComponent;
+import java.util.List;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizerInstantiationException;
 import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
 
 /**
@@ -32,9 +36,13 @@ public final class TraversalEngine {
 		}
 		final ClassMetadata meta = ClassMetadata.of(node.getClass());
 		if (meta.isRecord()) {
-			throw new UnsupportedOperationException(
-					"Records reached TraversalEngine but record support is not yet wired up: "
-							+ node.getClass().getName());
+			final Object cached = state.findReconstructed(node);
+			if (cached != null) {
+				return cached;
+			}
+			final Object built = walkRecord(node, meta);
+			state.storeReconstructed(node, built);
+			return built;
 		}
 		if (!state.markVisited(node)) {
 			return node;
@@ -43,8 +51,39 @@ public final class TraversalEngine {
 		return node;
 	}
 
+	private static Object walkRecord(final Object node, final ClassMetadata meta) {
+		LOG.debug("walk record class={} components={}", node.getClass().getName(), meta.fields().size());
+		final RecordComponent[] components = meta.components();
+		final Object[] args = new Object[components.length];
+		for (int i = 0; i < components.length; i++) {
+			final RecordComponent rc = components[i];
+			final FieldDescriptor d = meta.fields().get(i);
+			try {
+				final Object raw = rc.getAccessor().invoke(node);
+				args[i] = applyChain(raw, d.chain());
+			} catch (final IllegalAccessException e) {
+				throw new IllegalStateException(
+						"Cannot invoke accessor for component '" + rc.getName() + "' on " + node.getClass().getName(),
+						e);
+			} catch (final InvocationTargetException e) {
+				rethrowRuntime(e, "Record accessor threw");
+			} catch (final ClassCastException e) {
+				throw new IllegalStateException("Type mismatch: sanitizer chain incompatible with record component '"
+						+ rc.getName() + "' of type " + rc.getType().getName() + " on " + node.getClass().getName(), e);
+			}
+		}
+		try {
+			return meta.canonicalCtor().newInstance(args);
+		} catch (final InvocationTargetException e) {
+			rethrowRuntime(e, "Record canonical constructor threw checked exception");
+			return null; // unreachable
+		} catch (final ReflectiveOperationException e) {
+			throw new SanitizerInstantiationException("Cannot reconstruct record " + node.getClass().getName(), e);
+		}
+	}
+
 	private static void walkPojo(final Object node, final ClassMetadata meta) {
-		LOG.debug("walk class={} descriptors={}", node.getClass().getName(), meta.fields().size());
+		LOG.debug("walk pojo class={} fields={}", node.getClass().getName(), meta.fields().size());
 		for (final FieldDescriptor d : meta.fields()) {
 			final Field field = d.field();
 			if (field == null) {
@@ -66,8 +105,7 @@ public final class TraversalEngine {
 		}
 	}
 
-	private static @Nullable Object applyChain(final @Nullable Object raw,
-			final java.util.List<FieldSanitizer<Object>> chain) {
+	private static @Nullable Object applyChain(final @Nullable Object raw, final List<FieldSanitizer<Object>> chain) {
 		Object current = raw;
 		for (final FieldSanitizer<Object> s : chain) {
 			current = s.sanitize(current);
@@ -81,5 +119,13 @@ public final class TraversalEngine {
 			return;
 		}
 		field.set(node, sanitized);
+	}
+
+	private static void rethrowRuntime(final InvocationTargetException e, final String fallback) {
+		final Throwable cause = e.getCause() != null ? e.getCause() : e;
+		if (cause instanceof RuntimeException re) {
+			throw re;
+		}
+		throw new IllegalStateException(fallback, cause);
 	}
 }

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java
@@ -158,9 +158,7 @@ public final class TraversalEngine {
 						checker);
 			}
 			case MAP -> {
-				// Implemented in the next task.
-				LOG.warn("cascade into MAP not yet implemented; skipping");
-				return child;
+				return MapWalker.walk((java.util.Map<?, ?>) child, d.elementType(), d.chain(), state, checker);
 			}
 			case LEAF -> throw new IllegalStateException("Internal error: cascade descent reached LEAF for "
 					+ (d.field() != null ? d.field().getName() : d.recordComponent().getName()));

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java
@@ -1,0 +1,81 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.lang.reflect.Field;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+/**
+ * Recursive walker that applies sanitizers and (optionally) descends into a
+ * bean's object graph. Entry point:
+ * {@link #walk(Object, TraversalState, TraversalSafetyChecker)}.
+ */
+public final class TraversalEngine {
+
+	private static final Logger LOG = LoggerFactory.getLogger(TraversalEngine.class);
+
+	private TraversalEngine() {
+	}
+
+	public static @Nullable Object walk(final @Nullable Object node, final TraversalState state,
+			final TraversalSafetyChecker checker) {
+		if (node == null) {
+			return null;
+		}
+		final ClassMetadata meta = ClassMetadata.of(node.getClass());
+		if (meta.isRecord()) {
+			throw new UnsupportedOperationException(
+					"Records reached TraversalEngine but record support is not yet wired up: "
+							+ node.getClass().getName());
+		}
+		if (!state.markVisited(node)) {
+			return node;
+		}
+		walkPojo(node, meta);
+		return node;
+	}
+
+	private static void walkPojo(final Object node, final ClassMetadata meta) {
+		LOG.debug("walk class={} descriptors={}", node.getClass().getName(), meta.fields().size());
+		for (final FieldDescriptor d : meta.fields()) {
+			final Field field = d.field();
+			if (field == null) {
+				continue;
+			}
+			try {
+				final Object raw = field.get(node);
+				final Object sanitized = applyChain(raw, d.chain());
+				writeBackIfChanged(node, field, raw, sanitized);
+			} catch (final IllegalAccessException e) {
+				throw new IllegalStateException("Cannot access field '" + field.getName() + "' on "
+						+ node.getClass().getName() + ". Ensure the field is mutable and accessible.", e);
+			} catch (final ClassCastException e) {
+				throw new IllegalStateException("Type mismatch: sanitizer chain incompatible with field '"
+						+ field.getName() + "' of type " + field.getType().getName() + " on "
+						+ node.getClass().getName() + ". Ensure the sanitizer's generic type matches the field type.",
+						e);
+			}
+		}
+	}
+
+	private static @Nullable Object applyChain(final @Nullable Object raw,
+			final java.util.List<FieldSanitizer<Object>> chain) {
+		Object current = raw;
+		for (final FieldSanitizer<Object> s : chain) {
+			current = s.sanitize(current);
+		}
+		return current;
+	}
+
+	private static void writeBackIfChanged(final Object node, final Field field, final @Nullable Object raw,
+			final @Nullable Object sanitized) throws IllegalAccessException {
+		if (raw == null && sanitized == null) {
+			return;
+		}
+		field.set(node, sanitized);
+	}
+}

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngine.java
@@ -61,6 +61,15 @@ public final class TraversalEngine {
 			final FieldDescriptor d = meta.fields().get(i);
 			try {
 				final Object raw = rc.getAccessor().invoke(node);
+				if (d.kind() == Kind.COLLECTION || d.kind() == Kind.MAP) {
+					// For collections/maps the chain applies per-element, not to the
+					// container itself. Descend when cascade=true OR when a leaf chain
+					// is present (implicit leaf-element walk).
+					args[i] = (raw != null && (d.cascade() || !d.chain().isEmpty()))
+							? descendByKind(raw, d, state, checker)
+							: raw;
+					continue;
+				}
 				Object current = applyChain(raw, d.chain());
 				if (d.cascade() && current != null) {
 					current = descendByKind(current, d, state, checker);
@@ -96,6 +105,22 @@ public final class TraversalEngine {
 				continue;
 			}
 			try {
+				if (d.kind() == Kind.COLLECTION || d.kind() == Kind.MAP) {
+					// For collections/maps the chain applies per-element, not to the
+					// container itself. Descend when cascade=true OR when a leaf chain
+					// is present (implicit leaf-element walk).
+					final Object raw = field.get(node);
+					if (raw == null) {
+						continue;
+					}
+					if ((d.cascade() || !d.chain().isEmpty()) && checker.shouldDescend(node, field)) {
+						final Object after = descendByKind(raw, d, state, checker);
+						if (after != raw) {
+							field.set(node, after);
+						}
+					}
+					continue;
+				}
 				final Object raw = field.get(node);
 				final Object sanitized = applyChain(raw, d.chain());
 				writeBackIfChanged(node, field, raw, sanitized);
@@ -128,9 +153,13 @@ public final class TraversalEngine {
 				final Object replaced = walk(child, state, checker);
 				return replaced == null ? child : replaced;
 			}
-			case COLLECTION, MAP -> {
-				// Implemented in Tasks 11 and 12.
-				LOG.warn("cascade into {} not yet implemented; skipping", d.kind());
+			case COLLECTION -> {
+				return CollectionWalker.walk((java.util.Collection<?>) child, d.elementType(), d.chain(), state,
+						checker);
+			}
+			case MAP -> {
+				// Implemented in the next task.
+				LOG.warn("cascade into MAP not yet implemented; skipping");
 				return child;
 			}
 			case LEAF -> throw new IllegalStateException("Internal error: cascade descent reached LEAF for "

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalState.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalState.java
@@ -9,12 +9,12 @@ import org.jspecify.annotations.Nullable;
  * for cycle detection and reconstructed record instances keyed by their
  * original references.
  */
-public final class TraversalState {
+final class TraversalState {
 
 	private final IdentityHashMap<Object, Boolean> visited = new IdentityHashMap<>();
 	private final IdentityHashMap<Object, Object> reconstructedRecords = new IdentityHashMap<>();
 
-	public TraversalState() {
+	TraversalState() {
 	}
 
 	/**

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalState.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalState.java
@@ -1,0 +1,33 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.util.IdentityHashMap;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Mutable per-invocation traversal state. Tracks visited POJOs/collections/maps
+ * for cycle detection and reconstructed record instances keyed by their
+ * original references.
+ */
+final class TraversalState {
+
+	private final IdentityHashMap<Object, Boolean> visited = new IdentityHashMap<>();
+	private final IdentityHashMap<Object, Object> reconstructedRecords = new IdentityHashMap<>();
+
+	/**
+	 * @return true the first time this node is visited; false on every subsequent
+	 *         visit (indicates a cycle).
+	 */
+	boolean markVisited(final Object node) {
+		return visited.put(node, Boolean.TRUE) == null;
+	}
+
+	void storeReconstructed(final Object original, final Object rebuilt) {
+		reconstructedRecords.put(original, rebuilt);
+	}
+
+	@Nullable
+	Object findReconstructed(final Object original) {
+		return reconstructedRecords.get(original);
+	}
+}

--- a/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalState.java
+++ b/sanitizer-core/src/main/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalState.java
@@ -9,10 +9,13 @@ import org.jspecify.annotations.Nullable;
  * for cycle detection and reconstructed record instances keyed by their
  * original references.
  */
-final class TraversalState {
+public final class TraversalState {
 
 	private final IdentityHashMap<Object, Boolean> visited = new IdentityHashMap<>();
 	private final IdentityHashMap<Object, Object> reconstructedRecords = new IdentityHashMap<>();
+
+	public TraversalState() {
+	}
 
 	/**
 	 * @return true the first time this node is visited; false on every subsequent

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/annotation/SanitizeAnnotationTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/annotation/SanitizeAnnotationTest.java
@@ -1,0 +1,50 @@
+package io.github.rabinarayanpatra.sanitizer.annotation;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SanitizeAnnotationTest {
+
+	@Test
+	void cascadeDefaultsToFalse() throws NoSuchFieldException {
+		final Field field = Fixtures.class.getDeclaredField("trimmedOnly");
+		final Sanitize ann = field.getAnnotation(Sanitize.class);
+		assertFalse(ann.cascade());
+	}
+
+	@Test
+	void cascadeReadsTrueWhenSet() throws NoSuchFieldException {
+		final Field field = Fixtures.class.getDeclaredField("cascadeOnly");
+		final Sanitize ann = field.getAnnotation(Sanitize.class);
+		assertTrue(ann.cascade());
+		assertArrayEquals(new Class<?>[0], ann.using());
+	}
+
+	@Test
+	void cascadeCombinedWithUsing() throws NoSuchFieldException {
+		final Field field = Fixtures.class.getDeclaredField("trimAndCascade");
+		final Sanitize ann = field.getAnnotation(Sanitize.class);
+		assertTrue(ann.cascade());
+		assertEquals(1, ann.using().length);
+		assertEquals(TrimSanitizer.class, ann.using()[0]);
+	}
+
+	static class Fixtures {
+		@Sanitize(using = TrimSanitizer.class)
+		String trimmedOnly;
+
+		@Sanitize(cascade = true)
+		Object cascadeOnly;
+
+		@Sanitize(using = TrimSanitizer.class, cascade = true)
+		String trimAndCascade;
+	}
+}

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtilsBackwardCompatTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtilsBackwardCompatTest.java
@@ -1,0 +1,35 @@
+package io.github.rabinarayanpatra.sanitizer.core;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SanitizationUtilsBackwardCompatTest {
+
+	@Test
+	void nestedAnnotatedFieldUntouchedWhenCascadeOmitted() {
+		final Parent p = new Parent();
+		p.name = "  PARENT  ";
+		p.child = new Child();
+		p.child.name = "  CHILD  ";
+		SanitizationUtils.apply(p);
+		assertEquals("parent", p.name);
+		// Without cascade=true the engine must not descend.
+		assertEquals("  CHILD  ", p.child.name);
+	}
+
+	static class Parent {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		String name;
+		Child child; // no @Sanitize on field → not annotated, not walked
+	}
+
+	static class Child {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		String name;
+	}
+}

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtilsTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/SanitizationUtilsTest.java
@@ -41,12 +41,12 @@ class SanitizationUtilsTest {
 	}
 
 	@Test
-	void apply_throwsOnRecord() {
+	void apply_throwsIllegalArgumentOnRecord() {
 		final ImmutableRecord rec = new ImmutableRecord("  HELLO  ");
-		final UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class,
+		final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
 				() -> SanitizationUtils.apply(rec));
 		assertTrue(ex.getMessage().contains("ImmutableRecord"));
-		assertTrue(ex.getMessage().contains("records"));
+		assertTrue(ex.getMessage().contains("applyAndReturn"));
 	}
 
 	// --- P0: @Repeatable support ---

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/TraversalSafetyCheckerTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/TraversalSafetyCheckerTest.java
@@ -1,0 +1,28 @@
+package io.github.rabinarayanpatra.sanitizer.core;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TraversalSafetyCheckerTest {
+
+	@Test
+	void alwaysReturnsTrueForAnyParentAndField() throws NoSuchFieldException {
+		final Field field = Holder.class.getDeclaredField("name");
+		assertTrue(TraversalSafetyChecker.ALWAYS.shouldDescend(new Holder(), field));
+	}
+
+	@Test
+	void lambdaImplementationIsHonored() throws NoSuchFieldException {
+		final Field field = Holder.class.getDeclaredField("name");
+		final TraversalSafetyChecker neverDescend = (parent, f) -> false;
+		assertFalse(neverDescend.shouldDescend(new Holder(), field));
+	}
+
+	static class Holder {
+		String name;
+	}
+}

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadataTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadataTest.java
@@ -1,0 +1,185 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClassMetadataTest {
+
+	@Test
+	void leafTypesResolveToLeafKind() {
+		final ClassMetadata meta = ClassMetadata.of(LeafBean.class);
+		final Map<String, FieldDescriptor> byName = byFieldName(meta);
+		assertEquals(Kind.LEAF, byName.get("text").kind());
+		assertEquals(Kind.LEAF, byName.get("count").kind());
+		assertEquals(Kind.LEAF, byName.get("boxed").kind());
+		assertEquals(Kind.LEAF, byName.get("uuid").kind());
+		assertEquals(Kind.LEAF, byName.get("instant").kind());
+		assertEquals(Kind.LEAF, byName.get("amount").kind());
+		assertEquals(Kind.LEAF, byName.get("color").kind());
+	}
+
+	@Test
+	void recordIsDetectedAndCanonicalCtorCaptured() {
+		final ClassMetadata meta = ClassMetadata.of(SimpleRecord.class);
+		assertTrue(meta.isRecord());
+		assertNotNull(meta.canonicalCtor());
+		assertNotNull(meta.components());
+		assertEquals(1, meta.components().length);
+		assertEquals(1, meta.fields().size());
+		assertEquals(Kind.LEAF, meta.fields().get(0).kind());
+	}
+
+	@Test
+	void collectionFieldResolvesElementType() {
+		final ClassMetadata meta = ClassMetadata.of(CollectionBean.class);
+		final Map<String, FieldDescriptor> byName = byFieldName(meta);
+		assertEquals(Kind.COLLECTION, byName.get("names").kind());
+		assertSame(String.class, byName.get("names").elementType());
+		assertEquals(Kind.COLLECTION, byName.get("records").kind());
+		assertSame(SimpleRecord.class, byName.get("records").elementType());
+		assertEquals(Kind.MAP, byName.get("byName").kind());
+		assertSame(SimpleRecord.class, byName.get("byName").elementType());
+	}
+
+	@Test
+	void pojoFieldIsClassifiedAsPojo() {
+		final ClassMetadata meta = ClassMetadata.of(NestedBean.class);
+		final Map<String, FieldDescriptor> byName = byFieldName(meta);
+		assertEquals(Kind.POJO, byName.get("child").kind());
+	}
+
+	@Test
+	void cascadeTrueOnLeafFieldThrows() {
+		final IllegalStateException ex = assertThrows(IllegalStateException.class,
+				() -> ClassMetadata.of(IllegalLeafCascade.class));
+		assertTrue(ex.getMessage().contains("cascade"));
+		assertTrue(ex.getMessage().contains("text"));
+		assertTrue(ex.getMessage().contains("LEAF"));
+	}
+
+	@Test
+	void superclassFieldsWalked() {
+		final ClassMetadata meta = ClassMetadata.of(ChildAnnotated.class);
+		final Map<String, FieldDescriptor> byName = byFieldName(meta);
+		assertNotNull(byName.get("parentName"));
+		assertNotNull(byName.get("childName"));
+	}
+
+	@Test
+	void fieldWithoutSanitizeAnnotationIsSkipped() {
+		final ClassMetadata meta = ClassMetadata.of(PartiallyAnnotated.class);
+		assertEquals(1, meta.fields().size());
+		assertEquals("annotated", meta.fields().get(0).field().getName());
+	}
+
+	@Test
+	void emptyUsingArrayWithCascadeFalseIsRejected() {
+		final IllegalStateException ex = assertThrows(IllegalStateException.class,
+				() -> ClassMetadata.of(NoOpAnnotation.class));
+		assertTrue(ex.getMessage().contains("no sanitizer and cascade=false"));
+	}
+
+	@Test
+	void rawCollectionTypeReturnsNullElementType() {
+		final ClassMetadata meta = ClassMetadata.of(RawCollectionBean.class);
+		final FieldDescriptor d = meta.fields().get(0);
+		assertEquals(Kind.COLLECTION, d.kind());
+		assertNull(d.elementType());
+	}
+
+	private static Map<String, FieldDescriptor> byFieldName(final ClassMetadata meta) {
+		final java.util.Map<String, FieldDescriptor> m = new java.util.LinkedHashMap<>();
+		for (final FieldDescriptor d : meta.fields()) {
+			m.put(d.field() != null ? d.field().getName() : d.recordComponent().getName(), d);
+		}
+		return m;
+	}
+
+	enum Color {
+		RED, BLUE
+	}
+
+	static class LeafBean {
+		@Sanitize(using = TrimSanitizer.class)
+		String text;
+		@Sanitize(using = TrimSanitizer.class)
+		int count;
+		@Sanitize(using = TrimSanitizer.class)
+		Integer boxed;
+		@Sanitize(using = TrimSanitizer.class)
+		UUID uuid;
+		@Sanitize(using = TrimSanitizer.class)
+		Instant instant;
+		@Sanitize(using = TrimSanitizer.class)
+		BigDecimal amount;
+		@Sanitize(using = TrimSanitizer.class)
+		Color color;
+	}
+
+	record SimpleRecord(@Sanitize(using = TrimSanitizer.class) String value) {
+	}
+
+	static class CollectionBean {
+		@Sanitize(using = LowerCaseSanitizer.class)
+		List<String> names;
+		@Sanitize(cascade = true)
+		Set<SimpleRecord> records;
+		@Sanitize(cascade = true)
+		Map<String, SimpleRecord> byName;
+	}
+
+	static class NestedBean {
+		@Sanitize(cascade = true)
+		LeafBean child;
+	}
+
+	static class IllegalLeafCascade {
+		@Sanitize(cascade = true)
+		String text;
+	}
+
+	static class ParentAnnotated {
+		@Sanitize(using = TrimSanitizer.class)
+		String parentName;
+	}
+
+	static class ChildAnnotated extends ParentAnnotated {
+		@Sanitize(using = UpperCaseSanitizer.class)
+		String childName;
+	}
+
+	static class PartiallyAnnotated {
+		String unannotated;
+		@Sanitize(using = TrimSanitizer.class)
+		String annotated;
+	}
+
+	static class NoOpAnnotation {
+		@Sanitize
+		String pointless;
+	}
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	static class RawCollectionBean {
+		@Sanitize(cascade = true)
+		List raw;
+	}
+}

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadataTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/ClassMetadataTest.java
@@ -105,6 +105,34 @@ class ClassMetadataTest {
 		assertNull(d.elementType());
 	}
 
+	@Test
+	void typeReturnsTheBackingClass() {
+		// Covers the trivial accessor that was previously unreferenced.
+		final ClassMetadata meta = ClassMetadata.of(SimpleRecord.class);
+		assertSame(SimpleRecord.class, meta.type());
+	}
+
+	@Test
+	void nestedParameterizedElementResolvesToOuterRaw() {
+		// List<Map<String,String>>: target arg is a ParameterizedType, so
+		// resolveElementType returns the raw type (Map.class).
+		final ClassMetadata meta = ClassMetadata.of(NestedGenericBean.class);
+		final FieldDescriptor d = meta.fields().get(0);
+		assertEquals(Kind.COLLECTION, d.kind());
+		assertSame(Map.class, d.elementType());
+	}
+
+	@Test
+	void wildcardElementResolvesToNullElementType() {
+		// List<? extends SimpleRecord>: the type arg is a WildcardType (neither
+		// Class nor ParameterizedType) so elementType is null and the engine
+		// skips cascading at runtime.
+		final ClassMetadata meta = ClassMetadata.of(WildcardElementBean.class);
+		final FieldDescriptor d = meta.fields().get(0);
+		assertEquals(Kind.COLLECTION, d.kind());
+		assertNull(d.elementType());
+	}
+
 	private static Map<String, FieldDescriptor> byFieldName(final ClassMetadata meta) {
 		final java.util.Map<String, FieldDescriptor> m = new java.util.LinkedHashMap<>();
 		for (final FieldDescriptor d : meta.fields()) {
@@ -181,5 +209,15 @@ class ClassMetadataTest {
 	static class RawCollectionBean {
 		@Sanitize(cascade = true)
 		List raw;
+	}
+
+	static class NestedGenericBean {
+		@Sanitize(cascade = true)
+		List<Map<String, String>> nested;
+	}
+
+	static class WildcardElementBean {
+		@Sanitize(cascade = true)
+		List<? extends SimpleRecord> items;
 	}
 }

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/FieldDescriptorTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/FieldDescriptorTest.java
@@ -1,0 +1,34 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FieldDescriptorTest {
+
+	@Test
+	void pojoFieldDescriptorExposesFieldAndChain() throws NoSuchFieldException {
+		final Field f = Fixtures.class.getDeclaredField("name");
+		final List<FieldSanitizer<Object>> chain = List.of(new TrimSanitizer().asObjectSanitizer());
+		final FieldDescriptor d = FieldDescriptor.forPojoField(f, chain, false, Kind.LEAF, null);
+		assertSame(f, d.field());
+		assertNull(d.recordComponent());
+		assertEquals(chain, d.chain());
+		assertEquals(Kind.LEAF, d.kind());
+		assertNull(d.elementType());
+		assertTrue(!d.cascade());
+	}
+
+	static class Fixtures {
+		String name;
+	}
+}

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCascadeTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCascadeTest.java
@@ -1,0 +1,126 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class TraversalEngineCascadeTest {
+
+	@Test
+	void cascadeFalseLeavesNestedAnnotatedFieldUntouched_backwardCompat() {
+		final ParentNoCascade parent = new ParentNoCascade();
+		parent.name = "  PARENT  ";
+		parent.child = new Child();
+		parent.child.name = "  CHILD  ";
+		SanitizationUtils.apply(parent);
+		assertEquals("parent", parent.name);
+		// No cascade → child not touched
+		assertEquals("  CHILD  ", parent.child.name);
+	}
+
+	@Test
+	void cascadeTrueIntoPojoMutatesChildInPlace() {
+		final ParentWithCascade parent = new ParentWithCascade();
+		parent.name = "  PARENT  ";
+		parent.child = new Child();
+		parent.child.name = "  CHILD  ";
+		SanitizationUtils.apply(parent);
+		assertEquals("parent", parent.name);
+		assertEquals("child", parent.child.name);
+	}
+
+	@Test
+	void cascadeTrueIntoRecordReplacesField() {
+		final HoldsRecord parent = new HoldsRecord();
+		parent.embedded = new Embedded("  HELLO  ");
+		SanitizationUtils.apply(parent);
+		assertNotSame("  HELLO  ", parent.embedded.value());
+		assertEquals("HELLO", parent.embedded.value());
+	}
+
+	@Test
+	void recordRootCascadesIntoChildRecord() {
+		final OuterRec input = new OuterRec(new InnerRec("  hi  "));
+		final OuterRec out = SanitizationUtils.applyAndReturn(input);
+		assertNotSame(input, out);
+		assertEquals("HI", out.inner().value());
+	}
+
+	@Test
+	void cascadeOnlyAnnotationDescendsWithoutSelfSanitizer() {
+		final OnlyCascade parent = new OnlyCascade();
+		parent.child = new Child();
+		parent.child.name = "  CHILD  ";
+		SanitizationUtils.apply(parent);
+		assertEquals("child", parent.child.name);
+	}
+
+	@Test
+	void sharedRecordReferenceProducesSameReconstructedInstance() {
+		final Shared input = new Shared(new InnerRec("  hi  "));
+		final HoldsTwo parent = new HoldsTwo();
+		parent.left = input;
+		parent.right = input;
+		SanitizationUtils.apply(parent);
+		// The shared reference inside both Shared records is the same after
+		// reconstruction.
+		assertSame(parent.left.inner(), parent.right.inner());
+		assertEquals("HI", parent.left.inner().value());
+	}
+
+	static class ParentNoCascade {
+		@Sanitize(using = {TrimSanitizer.class, io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer.class})
+		String name;
+		Child child;
+	}
+
+	static class ParentWithCascade {
+		@Sanitize(using = {TrimSanitizer.class, io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer.class})
+		String name;
+		@Sanitize(cascade = true)
+		Child child;
+	}
+
+	static class Child {
+		@Sanitize(using = {TrimSanitizer.class, io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer.class})
+		String name;
+	}
+
+	static class HoldsRecord {
+		@Sanitize(cascade = true)
+		Embedded embedded;
+	}
+
+	record Embedded(@Sanitize(using = {
+			TrimSanitizer.class, UpperCaseSanitizer.class}) String value) {
+	}
+
+	record OuterRec(@Sanitize(cascade = true) InnerRec inner) {
+	}
+
+	record InnerRec(@Sanitize(using = {
+			TrimSanitizer.class, UpperCaseSanitizer.class}) String value) {
+	}
+
+	static class OnlyCascade {
+		@Sanitize(cascade = true)
+		Child child;
+	}
+
+	record Shared(@Sanitize(cascade = true) InnerRec inner) {
+	}
+
+	static class HoldsTwo {
+		@Sanitize(cascade = true)
+		Shared left;
+		@Sanitize(cascade = true)
+		Shared right;
+	}
+}

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCollectionTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCollectionTest.java
@@ -1,6 +1,9 @@
 package io.github.rabinarayanpatra.sanitizer.core.traversal;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -13,9 +16,11 @@ import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
 import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
 import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
 import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -93,6 +98,77 @@ class TraversalEngineCollectionTest {
 		b.raw = new ArrayList<Object>(List.of("ignored"));
 		SanitizationUtils.apply(b);
 		assertEquals(List.of("ignored"), b.raw);
+	}
+
+	@Test
+	void otherCollectionFieldRebuiltAsArrayList() {
+		// ArrayDeque is neither List nor Set → exercises the "other Collection"
+		// fallback branch in CollectionWalker.walk. The field is declared as
+		// Collection<String> so the rebuilt ArrayList is assignable.
+		final WithCollection b = new WithCollection();
+		b.values = new ArrayDeque<>(List.of("  A  ", "  B  "));
+		final Collection<String> before = b.values;
+		SanitizationUtils.apply(b);
+		assertNotSame(before, b.values);
+		assertEquals(Arrays.asList("a", "b"), new ArrayList<>(b.values));
+	}
+
+	@Test
+	void listWithNullElementIsPreservedAsNull() {
+		// Tests CollectionWalker.processElement's null-raw branch.
+		final WithStringList b = new WithStringList();
+		final ArrayList<String> values = new ArrayList<>();
+		values.add("  A  ");
+		values.add(null);
+		b.values = values;
+		SanitizationUtils.apply(b);
+		assertEquals("a", b.values.get(0));
+		assertNull(b.values.get(1));
+	}
+
+	@Test
+	void listOfListsTreatsInnerCollectionAsPojo() {
+		// element type is Collection → CollectionWalker.kindOf returns POJO;
+		// inner list is walked as a POJO (no @Sanitize fields, no-op) without
+		// crashing.
+		final WithListOfLists b = new WithListOfLists();
+		b.nested = new ArrayList<>();
+		b.nested.add(new ArrayList<>(List.of("untouched")));
+		SanitizationUtils.apply(b);
+		assertEquals(List.of(List.of("untouched")), b.nested);
+	}
+
+	@Test
+	void pojoListFieldSkippedWhenSafetyCheckerForbidsDescent() {
+		// Covers the walkPojo branch where shouldDescend returns false for a
+		// collection/map field (cascade=true but no descent).
+		final WithRecordList b = new WithRecordList();
+		final Item original = new Item("  HI  ");
+		b.items = new ArrayList<>(List.of(original));
+		final List<Item> before = b.items;
+		SanitizationUtils.applyAndReturn(b, (parent, field) -> false);
+		assertSame(before, b.items);
+		// Element untouched since descent was disallowed.
+		assertSame(original, b.items.get(0));
+	}
+
+	@Test
+	void nullCollectionFieldIsLeftAsNull() {
+		// Covers walkPojo's `raw == null` branch on COLLECTION/MAP kind.
+		final WithStringList b = new WithStringList();
+		b.values = null;
+		SanitizationUtils.applyAndReturn(b, TraversalSafetyChecker.ALWAYS);
+		assertNull(b.values);
+	}
+
+	static class WithCollection {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		Collection<String> values;
+	}
+
+	static class WithListOfLists {
+		@Sanitize(cascade = true)
+		List<Collection<String>> nested;
 	}
 
 	static class WithStringList {

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCollectionTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCollectionTest.java
@@ -1,0 +1,144 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TraversalEngineCollectionTest {
+
+	@Test
+	void listOfStringsLeafSanitizedInPlace() {
+		final WithStringList b = new WithStringList();
+		b.values = new ArrayList<>(List.of("  A  ", "  B  "));
+		final List<String> before = b.values;
+		SanitizationUtils.apply(b);
+		assertSame(before, b.values);
+		assertEquals(List.of("a", "b"), b.values);
+	}
+
+	@Test
+	void unmodifiableListOfStringsLeafSanitizedRebuiltAsArrayList() {
+		final WithStringList b = new WithStringList();
+		b.values = List.of("  A  ", "  B  ");
+		final List<String> before = b.values;
+		SanitizationUtils.apply(b);
+		assertNotSame(before, b.values);
+		assertTrue(b.values instanceof ArrayList<?>);
+		assertEquals(List.of("a", "b"), b.values);
+	}
+
+	@Test
+	void listOfRecordsRebuiltWithSanitizedInstances() {
+		final WithRecordList b = new WithRecordList();
+		b.items = new ArrayList<>(List.of(new Item("  HI  "), new Item("  YO  ")));
+		final List<Item> before = b.items;
+		SanitizationUtils.apply(b);
+		assertNotSame(before, b.items);
+		assertEquals("HI", b.items.get(0).value());
+		assertEquals("YO", b.items.get(1).value());
+	}
+
+	@Test
+	void listOfMutablePojosWalkedInPlace() {
+		final WithPojoList b = new WithPojoList();
+		b.children = new ArrayList<>(List.of(new Child("  A  "), new Child("  B  ")));
+		final List<Child> before = b.children;
+		final Child first = before.get(0);
+		SanitizationUtils.apply(b);
+		assertSame(before, b.children);
+		assertSame(first, b.children.get(0));
+		assertEquals("a", b.children.get(0).name);
+		assertEquals("b", b.children.get(1).name);
+	}
+
+	@Test
+	void setOfStringsRebuiltAsLinkedHashSetPreservingOrder() {
+		final WithStringSet b = new WithStringSet();
+		b.values = new LinkedHashSet<>(List.of("  A  ", "  B  ", "  C  "));
+		SanitizationUtils.apply(b);
+		final Iterator<String> it = b.values.iterator();
+		assertEquals("a", it.next());
+		assertEquals("b", it.next());
+		assertEquals("c", it.next());
+	}
+
+	@Test
+	void unmodifiableSetOfRecordsRebuilt() {
+		final WithRecordSet b = new WithRecordSet();
+		b.items = Set.of(new Item("  HI  "));
+		SanitizationUtils.apply(b);
+		assertEquals(1, b.items.size());
+		assertEquals("HI", b.items.iterator().next().value());
+	}
+
+	@Test
+	void rawCollectionFieldWithCascadeIsSkippedGracefully() {
+		// No element type → cascade is a no-op; should not throw.
+		final RawHolder b = new RawHolder();
+		b.raw = new ArrayList<Object>(List.of("ignored"));
+		SanitizationUtils.apply(b);
+		assertEquals(List.of("ignored"), b.raw);
+	}
+
+	static class WithStringList {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		List<String> values;
+	}
+
+	static class WithRecordList {
+		@Sanitize(cascade = true)
+		List<Item> items;
+	}
+
+	static class WithPojoList {
+		@Sanitize(cascade = true)
+		List<Child> children;
+	}
+
+	static class WithStringSet {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		Set<String> values;
+	}
+
+	static class WithRecordSet {
+		@Sanitize(cascade = true)
+		Set<Item> items;
+	}
+
+	record Item(@Sanitize(using = {
+			TrimSanitizer.class, UpperCaseSanitizer.class}) String value) {
+	}
+
+	static class Child {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		String name;
+
+		Child() {
+		}
+
+		Child(final String name) {
+			this.name = name;
+		}
+	}
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	static class RawHolder {
+		@Sanitize(cascade = true)
+		List raw;
+	}
+}

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCycleTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineCycleTest.java
@@ -1,0 +1,37 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+
+class TraversalEngineCycleTest {
+
+	@Test
+	void bidirectionalCycleTerminatesAndLabelsSanitizedOnce() {
+		final Node a = new Node();
+		a.label = "  A  ";
+		final Node b = new Node();
+		b.label = "  B  ";
+		a.next = b;
+		b.next = a;
+		assertTimeout(java.time.Duration.ofSeconds(2), () -> SanitizationUtils.apply(a));
+		assertEquals("a", a.label);
+		assertEquals("b", b.label);
+		assertSame(b, a.next);
+		assertSame(a, b.next);
+	}
+
+	static class Node {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		String label;
+		@Sanitize(cascade = true)
+		Node next;
+	}
+}

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineMapTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineMapTest.java
@@ -1,0 +1,64 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class TraversalEngineMapTest {
+
+	@Test
+	void mapOfStringToRecordRebuiltWithSanitizedValues() {
+		final Bean b = new Bean();
+		b.byKey = new LinkedHashMap<>();
+		b.byKey.put("a", new Item("  HI  "));
+		b.byKey.put("b", new Item("  YO  "));
+		final Map<String, Item> before = b.byKey;
+		SanitizationUtils.apply(b);
+		// Map ref may stay the same (mutable HashMap), values are replaced.
+		assertEquals("HI", b.byKey.get("a").value());
+		assertEquals("YO", b.byKey.get("b").value());
+		assertSame(before, b.byKey);
+	}
+
+	@Test
+	void mapKeysUntouched() {
+		final Bean b = new Bean();
+		b.byKey = new HashMap<>();
+		b.byKey.put("  KEY  ", new Item("  V  "));
+		SanitizationUtils.apply(b);
+		// Keys remain untouched; the original raw key is still present.
+		assertEquals(1, b.byKey.size());
+		assertSame("  KEY  ", b.byKey.keySet().iterator().next());
+		assertEquals("V", b.byKey.get("  KEY  ").value());
+	}
+
+	@Test
+	void unmodifiableMapRebuilt() {
+		final Bean b = new Bean();
+		b.byKey = Map.of("a", new Item("  X  "));
+		final Map<String, Item> before = b.byKey;
+		SanitizationUtils.apply(b);
+		assertNotSame(before, b.byKey);
+		assertEquals("X", b.byKey.get("a").value());
+	}
+
+	static class Bean {
+		@Sanitize(cascade = true)
+		Map<String, Item> byKey;
+	}
+
+	record Item(@Sanitize(using = {
+			TrimSanitizer.class, UpperCaseSanitizer.class}) String value) {
+	}
+}

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineMapTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineMapTest.java
@@ -1,5 +1,6 @@
 package io.github.rabinarayanpatra.sanitizer.core.traversal;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -7,12 +8,14 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
 import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
 import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
 import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 class TraversalEngineMapTest {
@@ -53,9 +56,71 @@ class TraversalEngineMapTest {
 		assertEquals("X", b.byKey.get("a").value());
 	}
 
+	@Test
+	void collectionsUnmodifiableMapRebuilt() {
+		// Collections.unmodifiableMap wraps in Collections$UnmodifiableMap;
+		// MapWalker#isUnmodifiable handles both ImmutableCollections$ (Map.of)
+		// and Collections$Unmodifiable* via separate string prefixes.
+		final Bean b = new Bean();
+		final Map<String, Item> wrapped = Collections
+				.unmodifiableMap(new LinkedHashMap<>(Map.of("a", new Item("  Y  "))));
+		b.byKey = wrapped;
+		SanitizationUtils.apply(b);
+		assertNotSame(wrapped, b.byKey);
+		assertEquals("Y", b.byKey.get("a").value());
+	}
+
+	@Test
+	void rawMapFieldWithCascadeIsSkippedGracefully() {
+		// Covers MapWalker#walk's valueType==null short-circuit (raw Map: no
+		// resolvable value type).
+		final RawHolder b = new RawHolder();
+		b.raw = new LinkedHashMap<>();
+		b.raw.put("k", new Item("  Z  "));
+		SanitizationUtils.apply(b);
+		// Item not sanitized because cascade was skipped.
+		assertEquals("  Z  ", ((Item) b.raw.get("k")).value());
+	}
+
+	@Test
+	void mapWithNullValueIsPreservedAsNull() {
+		// Triggers MapWalker#processValue null-raw branch.
+		final Bean b = new Bean();
+		b.byKey = new LinkedHashMap<>();
+		b.byKey.put("present", new Item("  X  "));
+		b.byKey.put("missing", null);
+		SanitizationUtils.apply(b);
+		assertEquals("X", b.byKey.get("present").value());
+		assertNull(b.byKey.get("missing"));
+	}
+
+	@Test
+	void mapOfStringValuesAppliesChainOnly() {
+		// Covers MapWalker#processValue's chain loop AND the branch where
+		// valueType is a String (skip recursive walk).
+		final StringValueBean b = new StringValueBean();
+		b.byKey = new LinkedHashMap<>();
+		b.byKey.put("k1", "  ONE  ");
+		b.byKey.put("k2", "  TWO  ");
+		SanitizationUtils.apply(b);
+		assertEquals("one", b.byKey.get("k1"));
+		assertEquals("two", b.byKey.get("k2"));
+	}
+
 	static class Bean {
 		@Sanitize(cascade = true)
 		Map<String, Item> byKey;
+	}
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	static class RawHolder {
+		@Sanitize(cascade = true)
+		Map raw;
+	}
+
+	static class StringValueBean {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		Map<String, String> byKey;
 	}
 
 	record Item(@Sanitize(using = {

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEnginePojoBaselineTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEnginePojoBaselineTest.java
@@ -1,0 +1,42 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class TraversalEnginePojoBaselineTest {
+
+	@Test
+	void walkSanitizesPojoFieldAndReturnsSameRef() {
+		final Bean b = new Bean();
+		b.name = "  HELLO  ";
+		final Object result = TraversalEngine.walk(b, new TraversalState(), TraversalSafetyChecker.ALWAYS);
+		assertSame(b, result);
+		assertEquals("hello", b.name);
+	}
+
+	@Test
+	void walkNullReturnsNull() {
+		assertNull(TraversalEngine.walk(null, new TraversalState(), TraversalSafetyChecker.ALWAYS));
+	}
+
+	@Test
+	void walkPojoWithNullFieldKeepsNull() {
+		final Bean b = new Bean();
+		b.name = null;
+		TraversalEngine.walk(b, new TraversalState(), TraversalSafetyChecker.ALWAYS);
+		assertNull(b.name);
+	}
+
+	static class Bean {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		String name;
+	}
+}

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineRecordTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineRecordTest.java
@@ -1,0 +1,90 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TraversalEngineRecordTest {
+
+	@Test
+	void recordRootIsReconstructedWithSanitizedComponent() {
+		final Simple input = new Simple("  HELLO  ");
+		final Simple out = SanitizationUtils.applyAndReturn(input);
+		assertNotSame(input, out);
+		assertEquals("hello", out.value());
+	}
+
+	@Test
+	void recordComponentWithoutAnnotationPassesThrough() {
+		final Mixed input = new Mixed("  HELLO  ", 42);
+		final Mixed out = SanitizationUtils.applyAndReturn(input);
+		assertEquals("hello", out.value());
+		assertEquals(42, out.count());
+	}
+
+	@Test
+	void recordWithNullComponentReconstructed() {
+		final Simple input = new Simple(null);
+		final Simple out = SanitizationUtils.applyAndReturn(input);
+		assertNotSame(input, out);
+		assertNull(out.value());
+	}
+
+	@Test
+	void applyAndReturnNullReturnsNull() {
+		assertNull(SanitizationUtils.applyAndReturn(null));
+	}
+
+	@Test
+	void applyAndReturnPojoReturnsSameRef() {
+		final PojoBean b = new PojoBean();
+		b.name = "  HELLO  ";
+		final PojoBean out = SanitizationUtils.applyAndReturn(b);
+		assertEquals(System.identityHashCode(b), System.identityHashCode(out));
+		assertEquals("hello", out.name);
+	}
+
+	@Test
+	void compactConstructorValidationPropagatesAsCause() {
+		final Validated input = new Validated("  HELLO  ");
+		final RuntimeException ex = assertThrows(RuntimeException.class,
+				() -> SanitizationUtils.applyAndReturn(new Validated("   ")));
+		assertTrue(ex.getCause() instanceof IllegalArgumentException || ex instanceof IllegalArgumentException
+				|| ex.getMessage().contains("must not be blank"));
+		assertEquals("  HELLO  ", input.value());
+	}
+
+	record Simple(@Sanitize(using = {
+			TrimSanitizer.class, LowerCaseSanitizer.class}) String value) {
+	}
+
+	record Mixed(@Sanitize(using = {
+			TrimSanitizer.class, LowerCaseSanitizer.class}) String value, int count) {
+	}
+
+	record Validated(@Sanitize(using = TrimSanitizer.class) String value) {
+		public Validated {
+			if (value == null || value.isBlank()) {
+				throw new IllegalArgumentException("value must not be blank");
+			}
+		}
+	}
+
+	static class PojoBean {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		String name;
+	}
+
+	@SuppressWarnings("unused")
+	private static final Class<?> KEEP_IMPORT = UpperCaseSanitizer.class;
+}

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineRecordTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineRecordTest.java
@@ -1,5 +1,10 @@
 package io.github.rabinarayanpatra.sanitizer.core.traversal;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
@@ -64,6 +69,75 @@ class TraversalEngineRecordTest {
 		assertEquals("  HELLO  ", input.value());
 	}
 
+	@Test
+	void canonicalCtorRuntimeExceptionAfterSanitizationIsRethrown() {
+		// Sanitizer turns input into null; compact ctor rejects null. This
+		// exercises the InvocationTargetException catch on the canonical
+		// constructor call and the RuntimeException branch of rethrowRuntime.
+		final RuntimeException ex = assertThrows(RuntimeException.class,
+				() -> SanitizationUtils.applyAndReturn(new NullRejecting("blank-makes-me-null")));
+		assertTrue(ex instanceof IllegalStateException || ex.getMessage().contains("rejected null"));
+	}
+
+	@Test
+	void canonicalCtorErrorWrappedAsIllegalStateException() {
+		// Throw a non-RuntimeException Throwable (Error) from compact ctor body
+		// only on reconstruction, so we can build the original then trigger the
+		// fallback branch in rethrowRuntime where the cause is not a
+		// RuntimeException.
+		final ErrorThrower input = new ErrorThrower("anything");
+		ErrorThrower.failNext = true;
+		try {
+			final IllegalStateException ex = assertThrows(IllegalStateException.class,
+					() -> SanitizationUtils.applyAndReturn(input));
+			assertTrue(ex.getMessage().contains("Record canonical constructor"));
+			assertTrue(ex.getCause() instanceof Error);
+		} finally {
+			ErrorThrower.failNext = false;
+		}
+	}
+
+	@Test
+	void recordWithListCollectionCascadesIntoElements() {
+		// Exercises walkRecord's COLLECTION/MAP branch (lines 64-71): the chain
+		// applies per-element and the descended collection is placed into the
+		// reconstructed record.
+		final WithList input = new WithList(new ArrayList<>(List.of("  A  ", "  B  ")));
+		final WithList out = SanitizationUtils.applyAndReturn(input);
+		assertEquals(List.of("a", "b"), out.values());
+	}
+
+	@Test
+	void recordWithMapCollectionCascadesIntoValues() {
+		final LinkedHashMap<String, String> map = new LinkedHashMap<>();
+		map.put("first", "  A  ");
+		map.put("second", "  B  ");
+		final WithMap input = new WithMap(map);
+		final WithMap out = SanitizationUtils.applyAndReturn(input);
+		assertEquals("a", out.byKey().get("first"));
+		assertEquals("b", out.byKey().get("second"));
+	}
+
+	@Test
+	void recordWithNullCollectionComponentLeftAsNull() {
+		// Triggers the (raw != null) false branch of the conditional in the
+		// COLLECTION/MAP branch of walkRecord.
+		final WithList out = SanitizationUtils.applyAndReturn(new WithList(null));
+		assertNull(out.values());
+	}
+
+	@Test
+	void recordChainTypeMismatchProducesIllegalState() {
+		// Trim sanitizer (FieldSanitizer<String>) applied to Integer component:
+		// triggers ClassCastException in applyChain, caught at walkRecord and
+		// rewrapped as IllegalStateException with the component name.
+		final IllegalStateException ex = assertThrows(IllegalStateException.class,
+				() -> SanitizationUtils.applyAndReturn(new MismatchedRecord(42)));
+		assertTrue(ex.getMessage().contains("Type mismatch"));
+		assertTrue(ex.getMessage().contains("count"));
+		assertTrue(ex.getCause() instanceof ClassCastException);
+	}
+
 	record Simple(@Sanitize(using = {
 			TrimSanitizer.class, LowerCaseSanitizer.class}) String value) {
 	}
@@ -78,6 +152,45 @@ class TraversalEngineRecordTest {
 				throw new IllegalArgumentException("value must not be blank");
 			}
 		}
+	}
+
+	public static class NullingSanitizer implements io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer<String> {
+		public NullingSanitizer() {
+		}
+
+		@Override
+		public @org.jspecify.annotations.Nullable String sanitize(
+				final @org.jspecify.annotations.Nullable String input) {
+			return null;
+		}
+	}
+
+	record NullRejecting(@Sanitize(using = NullingSanitizer.class) String value) {
+		public NullRejecting {
+			if (value == null) {
+				throw new IllegalStateException("rejected null in canonical ctor");
+			}
+		}
+	}
+
+	record ErrorThrower(@Sanitize(using = TrimSanitizer.class) String value) {
+		static boolean failNext;
+		public ErrorThrower {
+			if (failNext) {
+				throw new java.io.IOError(new RuntimeException("boom from ctor"));
+			}
+		}
+	}
+
+	record WithList(@Sanitize(using = {
+			TrimSanitizer.class, LowerCaseSanitizer.class}) List<String> values) {
+	}
+
+	record WithMap(@Sanitize(using = {
+			TrimSanitizer.class, LowerCaseSanitizer.class}) Map<String, String> byKey) {
+	}
+
+	record MismatchedRecord(@Sanitize(using = TrimSanitizer.class) Integer count) {
 	}
 
 	static class PojoBean {

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineSafetyCheckerTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineSafetyCheckerTest.java
@@ -1,0 +1,50 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TraversalEngineSafetyCheckerTest {
+
+	@Test
+	void checkerReturningFalseSkipsDescentButRunsSelfSanitizers() {
+		final Parent p = new Parent();
+		p.name = "  PARENT  ";
+		p.child = new Child();
+		p.child.name = "  CHILD  ";
+		final TraversalSafetyChecker neverDescend = (parent, field) -> false;
+		SanitizationUtils.applyAndReturn(p, neverDescend);
+		assertEquals("parent", p.name);
+		// Cascade skipped → child name untouched.
+		assertEquals("  CHILD  ", p.child.name);
+	}
+
+	@Test
+	void checkerReturningTrueAllowsDescent() {
+		final Parent p = new Parent();
+		p.name = "  PARENT  ";
+		p.child = new Child();
+		p.child.name = "  CHILD  ";
+		SanitizationUtils.applyAndReturn(p, TraversalSafetyChecker.ALWAYS);
+		assertEquals("parent", p.name);
+		assertEquals("child", p.child.name);
+	}
+
+	static class Parent {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		String name;
+		@Sanitize(cascade = true)
+		Child child;
+	}
+
+	static class Child {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		String name;
+	}
+}

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineSafetyCheckerTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalEngineSafetyCheckerTest.java
@@ -36,6 +36,36 @@ class TraversalEngineSafetyCheckerTest {
 		assertEquals("child", p.child.name);
 	}
 
+	@Test
+	void cascadeFieldWithChainReturningNullSkipsDescent() {
+		// Covers the (sanitized != null) middle clause of walkPojo's cascade
+		// guard: a sanitizer that returns null on a cascade=true POJO field
+		// should write back null and skip descent (no NPE).
+		final NullableHolder b = new NullableHolder();
+		b.child = new Child();
+		b.child.name = "  CHILD  ";
+		SanitizationUtils.applyAndReturn(b, TraversalSafetyChecker.ALWAYS);
+		// child is replaced with null because the chain returned null.
+		org.junit.jupiter.api.Assertions.assertNull(b.child);
+	}
+
+	public static class NullingChildSanitizer
+			implements
+				io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer<Child> {
+		public NullingChildSanitizer() {
+		}
+
+		@Override
+		public @org.jspecify.annotations.Nullable Child sanitize(final @org.jspecify.annotations.Nullable Child input) {
+			return null;
+		}
+	}
+
+	static class NullableHolder {
+		@Sanitize(using = NullingChildSanitizer.class, cascade = true)
+		Child child;
+	}
+
 	static class Parent {
 		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
 		String name;

--- a/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalStateTest.java
+++ b/sanitizer-core/src/test/java/io/github/rabinarayanpatra/sanitizer/core/traversal/TraversalStateTest.java
@@ -1,0 +1,29 @@
+package io.github.rabinarayanpatra.sanitizer.core.traversal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TraversalStateTest {
+
+	@Test
+	void markVisitedReturnsTrueOnFirstVisitAndFalseOnRevisit() {
+		final TraversalState state = new TraversalState();
+		final Object node = new Object();
+		assertTrue(state.markVisited(node));
+		assertFalse(state.markVisited(node));
+	}
+
+	@Test
+	void recordsAreStoredAndRetrievedByIdentity() {
+		final TraversalState state = new TraversalState();
+		final String original = "a";
+		final String rebuilt = "A";
+		assertNull(state.findReconstructed(original));
+		state.storeReconstructed(original, rebuilt);
+		assertSame(rebuilt, state.findReconstructed(original));
+	}
+}

--- a/sanitizer-jpa-spring/build.gradle.kts
+++ b/sanitizer-jpa-spring/build.gradle.kts
@@ -1,0 +1,10 @@
+dependencies {
+    api(project(":sanitizer-core"))
+    api(project(":sanitizer-jpa"))
+    api(project(":sanitizer-spring"))
+    implementation("org.springframework.boot:spring-boot-autoconfigure")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.h2database:h2")
+}

--- a/sanitizer-jpa-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/HibernateSafetyChecker.java
+++ b/sanitizer-jpa-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/HibernateSafetyChecker.java
@@ -1,0 +1,28 @@
+package io.github.rabinarayanpatra.sanitizer.jpa.spring;
+
+import java.lang.reflect.Field;
+
+import jakarta.persistence.PersistenceUnitUtil;
+
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+/**
+ * {@link TraversalSafetyChecker} that defers to Hibernate's
+ * {@link PersistenceUnitUtil#isLoaded(Object, String)} so the traversal engine
+ * skips lazy associations that have not been initialized.
+ *
+ * @since 1.2.0
+ */
+public final class HibernateSafetyChecker implements TraversalSafetyChecker {
+
+	private final PersistenceUnitUtil util;
+
+	public HibernateSafetyChecker(final PersistenceUnitUtil util) {
+		this.util = util;
+	}
+
+	@Override
+	public boolean shouldDescend(final Object parent, final Field field) {
+		return util.isLoaded(parent, field.getName());
+	}
+}

--- a/sanitizer-jpa-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/SanitizerJpaAutoConfiguration.java
+++ b/sanitizer-jpa-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/SanitizerJpaAutoConfiguration.java
@@ -1,0 +1,57 @@
+package io.github.rabinarayanpatra.sanitizer.jpa.spring;
+
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnitUtil;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.resource.beans.container.spi.BeanContainer;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.orm.hibernate5.SpringBeanContainer;
+import org.springframework.orm.jpa.SharedEntityManagerCreator;
+
+import io.github.rabinarayanpatra.sanitizer.jpa.SanitizationEntityListener;
+
+/**
+ * Spring Boot auto-configuration that exposes a {@link HibernateSafetyChecker}
+ * and configures Hibernate to instantiate {@link SanitizationEntityListener}
+ * through Spring's {@link SpringBeanContainer}. The listener picks up the
+ * checker as a setter-injected dependency.
+ *
+ * @since 1.2.0
+ */
+@AutoConfiguration
+@ConditionalOnClass({EntityManagerFactory.class, BeanContainer.class})
+public class SanitizerJpaAutoConfiguration {
+
+	// SharedEntityManagerCreator is referenced to ensure Spring's JPA support is on
+	// the classpath at compile time; it is not used at runtime here.
+	@SuppressWarnings("unused")
+	private static final Class<?> SHARED = SharedEntityManagerCreator.class;
+
+	@Bean
+	@ConditionalOnMissingBean
+	public HibernateSafetyChecker hibernateSafetyChecker(final EntityManagerFactory emf) {
+		final PersistenceUnitUtil util = emf.getPersistenceUnitUtil();
+		return new HibernateSafetyChecker(util);
+	}
+
+	@Bean
+	@ConditionalOnBean(HibernateSafetyChecker.class)
+	public SanitizationEntityListener sanitizationEntityListener(final HibernateSafetyChecker checker) {
+		final SanitizationEntityListener listener = new SanitizationEntityListener();
+		listener.setSafetyChecker(checker);
+		return listener;
+	}
+
+	@Bean
+	public HibernatePropertiesCustomizer sanitizerSpringBeanContainerCustomizer(
+			final ConfigurableListableBeanFactory beanFactory) {
+		return properties -> properties.put(AvailableSettings.BEAN_CONTAINER, new SpringBeanContainer(beanFactory));
+	}
+}

--- a/sanitizer-jpa-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sanitizer-jpa-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.github.rabinarayanpatra.sanitizer.jpa.spring.SanitizerJpaAutoConfiguration

--- a/sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/HibernateSafetyCheckerTest.java
+++ b/sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/HibernateSafetyCheckerTest.java
@@ -1,0 +1,43 @@
+package io.github.rabinarayanpatra.sanitizer.jpa.spring;
+
+import java.lang.reflect.Field;
+
+import jakarta.persistence.PersistenceUnitUtil;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HibernateSafetyCheckerTest {
+
+	@Test
+	void shouldDescendReturnsFalseForUnloadedFieldName() throws NoSuchFieldException {
+		final PersistenceUnitUtil util = mock(PersistenceUnitUtil.class);
+		final Holder holder = new Holder();
+		final Field field = Holder.class.getDeclaredField("children");
+		when(util.isLoaded(any(), eq("children"))).thenReturn(false);
+		final TraversalSafetyChecker checker = new HibernateSafetyChecker(util);
+		assertFalse(checker.shouldDescend(holder, field));
+	}
+
+	@Test
+	void shouldDescendReturnsTrueForLoadedFieldName() throws NoSuchFieldException {
+		final PersistenceUnitUtil util = mock(PersistenceUnitUtil.class);
+		final Holder holder = new Holder();
+		final Field field = Holder.class.getDeclaredField("children");
+		when(util.isLoaded(any(), eq("children"))).thenReturn(true);
+		final TraversalSafetyChecker checker = new HibernateSafetyChecker(util);
+		assertTrue(checker.shouldDescend(holder, field));
+	}
+
+	static class Holder {
+		java.util.List<String> children;
+	}
+}

--- a/sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/LazyAssociationIntegrationTest.java
+++ b/sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/LazyAssociationIntegrationTest.java
@@ -1,0 +1,86 @@
+package io.github.rabinarayanpatra.sanitizer.jpa.spring;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.jpa.SanitizationEntityListener;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+@AutoConfigureTestDatabase
+@Import(SanitizerJpaAutoConfiguration.class)
+class LazyAssociationIntegrationTest {
+
+	@Autowired
+	TestEntityManager em;
+
+	@SpringBootConfiguration
+	@EnableAutoConfiguration
+	static class TestConfig {
+	}
+
+	@Test
+	void persistParentDoesNotInitializeLazyChildren() {
+		final Department dept = new Department();
+		dept.name = "  ENG  ";
+		final Department persisted = em.persistFlushFind(dept);
+		em.clear();
+		final Department reloaded = em.find(Department.class, persisted.id);
+		// children association is lazy and not touched; sanitization must succeed
+		// without LazyInitializationException.
+		reloaded.name = "  ENG-2  ";
+		em.persistAndFlush(reloaded);
+		assertEquals("eng-2", reloaded.name);
+	}
+
+	@Entity
+	@EntityListeners(SanitizationEntityListener.class)
+	static class Department implements Serializable {
+		@Id
+		@GeneratedValue
+		Long id;
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		String name;
+		@Sanitize(cascade = true)
+		@OneToMany(mappedBy = "department", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+		List<Employee> employees = new ArrayList<>();
+	}
+
+	@Entity
+	@EntityListeners(SanitizationEntityListener.class)
+	static class Employee implements Serializable {
+		@Id
+		@GeneratedValue
+		Long id;
+		@Sanitize(using = {TrimSanitizer.class, UpperCaseSanitizer.class})
+		String code;
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "department_id")
+		Department department;
+	}
+}

--- a/sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/SanitizerJpaAutoConfigurationTest.java
+++ b/sanitizer-jpa-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/spring/SanitizerJpaAutoConfigurationTest.java
@@ -1,0 +1,65 @@
+package io.github.rabinarayanpatra.sanitizer.jpa.spring;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.jpa.SanitizationEntityListener;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DataJpaTest
+@AutoConfigureTestDatabase
+@Import(SanitizerJpaAutoConfiguration.class)
+class SanitizerJpaAutoConfigurationTest {
+
+	@SpringBootConfiguration
+	@EnableAutoConfiguration
+	static class TestConfig {
+	}
+
+	@Autowired
+	TestEntityManager em;
+
+	@Autowired
+	HibernateSafetyChecker checker;
+
+	@Test
+	void contextWiresHibernateSafetyCheckerBean() {
+		assertNotNull(checker);
+	}
+
+	@Test
+	void persistRunsListenerAndSanitizesTopLevelField() {
+		final UserEntity u = new UserEntity();
+		u.email = "  USER@EXAMPLE.COM  ";
+		final UserEntity saved = em.persistFlushFind(u);
+		assertEquals("user@example.com", saved.email);
+	}
+
+	@Entity
+	@EntityListeners(SanitizationEntityListener.class)
+	static class UserEntity implements Serializable {
+		@Id
+		@GeneratedValue
+		Long id;
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		String email;
+	}
+}

--- a/sanitizer-jpa/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/SanitizationEntityListener.java
+++ b/sanitizer-jpa/src/main/java/io/github/rabinarayanpatra/sanitizer/jpa/SanitizationEntityListener.java
@@ -1,58 +1,43 @@
 package io.github.rabinarayanpatra.sanitizer.jpa;
 
-import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
-import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 
+import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
 /**
- * JPA entity listener that automatically applies sanitization to any entity
- * fields annotated with {@link Sanitize @Sanitize} before they are persisted or
- * updated.
+ * JPA entity listener that applies sanitizers before persist and before update.
+ * Wire it up by annotating an entity (or a {@code @MappedSuperclass}) with
+ * {@code @EntityListeners(SanitizationEntityListener.class)}.
+ *
  * <p>
- * Internally this listener invokes {@link SanitizationUtils#apply(Object)} to
- * run through all configured
- * {@link io.github.rabinarayanpatra.sanitizer.core.FieldSanitizer}s.
- *
- * <pre>
- * {
- * 	&#64;code
- * 	&#64;Entity
- * 	&#64;EntityListeners(SanitizationEntityListener.class)
- * 	public class Customer {
- *
- * 		&#64;Sanitize(using = TrimSanitizer.class)
- * 		&#64;Sanitize(using = CollapseWhitespaceSanitizer.class)
- * 		private String name;
- *
- * 		// getters/setters...
- * 	}
- * }
- * </pre>
+ * In a Spring + Hibernate context, the listener is instantiated by Hibernate.
+ * Use the {@code sanitizer-jpa-spring} starter to wire a Hibernate-aware
+ * {@link TraversalSafetyChecker} that skips lazy associations.
  *
  * @since 1.0.0
  */
 public class SanitizationEntityListener {
 
-	/**
-	 * Default constructor.
-	 */
-	public SanitizationEntityListener() {
-	}
+	private TraversalSafetyChecker safetyChecker = TraversalSafetyChecker.ALWAYS;
 
 	/**
-	 * Lifecycle callback invoked by JPA before an entity is inserted or updated.
-	 * <p>
-	 * Calls {@link SanitizationUtils#apply(Object)} on the given entity instance,
-	 * sanitizing any fields marked with {@link Sanitize @Sanitize}.
+	 * Overrides the default {@link TraversalSafetyChecker#ALWAYS} checker. Spring
+	 * auto-configuration in {@code sanitizer-jpa-spring} calls this with a
+	 * Hibernate-aware implementation.
 	 *
-	 * @param entity
-	 *            the entity instance about to be persisted or updated; never
-	 *            {@code null}
+	 * @param safetyChecker
+	 *            the checker to use for all subsequent {@link #onSave(Object)}
+	 *            invocations; must not be null
 	 */
+	public void setSafetyChecker(final TraversalSafetyChecker safetyChecker) {
+		this.safetyChecker = safetyChecker;
+	}
+
 	@PrePersist
 	@PreUpdate
 	public void onSave(final Object entity) {
-		SanitizationUtils.apply(entity);
+		SanitizationUtils.applyAndReturn(entity, safetyChecker);
 	}
 }

--- a/sanitizer-jpa/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/SanitizationEntityListenerTest.java
+++ b/sanitizer-jpa/src/test/java/io/github/rabinarayanpatra/sanitizer/jpa/SanitizationEntityListenerTest.java
@@ -1,0 +1,64 @@
+package io.github.rabinarayanpatra.sanitizer.jpa;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.LowerCaseSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.core.TraversalSafetyChecker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SanitizationEntityListenerTest {
+
+	@Test
+	void onSaveSanitizesTopLevelFields() {
+		final Entity e = new Entity();
+		e.name = "  HELLO  ";
+		new SanitizationEntityListener().onSave(e);
+		assertEquals("hello", e.name);
+	}
+
+	@Test
+	void customSafetyCheckerIsHonored() {
+		final Parent p = new Parent();
+		p.name = "  PARENT  ";
+		p.child = new Child();
+		p.child.name = "  CHILD  ";
+		final SanitizationEntityListener listener = new SanitizationEntityListener();
+		listener.setSafetyChecker((parent, field) -> false);
+		listener.onSave(p);
+		assertEquals("parent", p.name);
+		assertEquals("  CHILD  ", p.child.name);
+	}
+
+	@Test
+	void defaultSafetyCheckerAllowsDescent() {
+		final Parent p = new Parent();
+		p.name = "  PARENT  ";
+		p.child = new Child();
+		p.child.name = "  CHILD  ";
+		final SanitizationEntityListener listener = new SanitizationEntityListener();
+		listener.setSafetyChecker(TraversalSafetyChecker.ALWAYS);
+		listener.onSave(p);
+		assertEquals("parent", p.name);
+		assertEquals("child", p.child.name);
+	}
+
+	static class Entity {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		String name;
+	}
+
+	static class Parent {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		String name;
+		@Sanitize(cascade = true)
+		Child child;
+	}
+
+	static class Child {
+		@Sanitize(using = {TrimSanitizer.class, LowerCaseSanitizer.class})
+		String name;
+	}
+}

--- a/sanitizer-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/spring/jackson/SanitizerModule.java
+++ b/sanitizer-spring/src/main/java/io/github/rabinarayanpatra/sanitizer/spring/jackson/SanitizerModule.java
@@ -19,9 +19,11 @@ import io.github.rabinarayanpatra.sanitizer.core.SanitizationUtils;
  * during JSON deserialization.
  * <p>
  * This module wraps default bean deserializers and invokes
- * {@link SanitizationUtils#apply(Object)} immediately after a bean is fully
- * deserialized, ensuring field sanitization happens automatically for incoming
- * JSON.
+ * {@link SanitizationUtils#applyAndReturn(Object)} immediately after a bean is
+ * fully deserialized. For mutable POJOs the same instance is returned with
+ * fields mutated in place; for records the engine reconstructs a new instance
+ * with sanitized components and returns it in place of the raw deserialized
+ * record.
  *
  * @since 1.0.0
  */
@@ -69,8 +71,7 @@ public final class SanitizerModule extends SimpleModule {
 		@Override
 		public Object deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException {
 			final Object bean = super.deserialize(p, ctxt);
-			SanitizationUtils.apply(bean);
-			return bean;
+			return SanitizationUtils.applyAndReturn(bean);
 		}
 
 		/**

--- a/sanitizer-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/spring/jackson/SanitizerModuleRecordIntegrationTest.java
+++ b/sanitizer-spring/src/test/java/io/github/rabinarayanpatra/sanitizer/spring/jackson/SanitizerModuleRecordIntegrationTest.java
@@ -1,0 +1,35 @@
+package io.github.rabinarayanpatra.sanitizer.spring.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.rabinarayanpatra.sanitizer.annotation.Sanitize;
+import io.github.rabinarayanpatra.sanitizer.builtin.TrimSanitizer;
+import io.github.rabinarayanpatra.sanitizer.builtin.UpperCaseSanitizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SanitizerModuleRecordIntegrationTest {
+
+	@Test
+	void deserializeRecord_sanitizesComponents() throws Exception {
+		final ObjectMapper mapper = new ObjectMapper().registerModule(new SanitizerModule());
+		final RecordDto dto = mapper.readValue("{\"value\":\"  hi  \"}", RecordDto.class);
+		assertEquals("HI", dto.value());
+	}
+
+	@Test
+	void deserializeNestedRecordWithCascade_sanitizesNested() throws Exception {
+		final ObjectMapper mapper = new ObjectMapper().registerModule(new SanitizerModule());
+		final OuterDto dto = mapper.readValue("{\"inner\":{\"value\":\"  hi  \"}}", OuterDto.class);
+		assertEquals("HI", dto.inner().value());
+	}
+
+	record RecordDto(@Sanitize(using = {
+			TrimSanitizer.class, UpperCaseSanitizer.class}) String value) {
+	}
+
+	record OuterDto(@Sanitize(cascade = true) RecordDto inner) {
+	}
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,2 @@
 rootProject.name = "sanitizer-lib"
-include("sanitizer-core", "sanitizer-spring", "sanitizer-jpa")
+include("sanitizer-core", "sanitizer-spring", "sanitizer-jpa", "sanitizer-jpa-spring")


### PR DESCRIPTION
## Summary
- Add Java records support via new `SanitizationUtils.applyAndReturn(T)` entry point.
- Add opt-in recursive traversal via `@Sanitize(cascade = true)` for nested objects, records, collections, and maps.
- Add `TraversalSafetyChecker` interface for pluggable graph-walk gating.
- Add new `sanitizer-jpa-spring` module with `HibernateSafetyChecker` to skip non-initialized lazy associations.
- 100% source/binary compatible with v1.1.0. POJO behavior bit-identical without `cascade=true`.

Spec: `docs/superpowers/specs/2026-06-05-records-and-traversal-engine-design.md`
Plan: `docs/superpowers/plans/2026-06-05-records-and-traversal-engine.md`

## Architecture

New package `core.traversal` (package-private internals): `TraversalEngine`, `ClassMetadata`, `FieldDescriptor`, `TraversalState`, `CollectionWalker`, `MapWalker`. `SanitizationUtils` is now a thin facade delegating to the engine.

`@Sanitize` gains optional `cascade()` attribute (default `false`); `using()` defaults to `{}` so a field can opt in to cascade without supplying a self-sanitizer.

For `@Sanitize(using=Trim.class) List<String>` ergonomics, the engine descends into Collection/Map fields automatically when the field has a non-empty sanitizer chain (chain applies per-element). Explicit `cascade=true` is required only when walking POJO/RECORD child objects.

Records are reconstructed via canonical constructor. Shared-record references in the graph reconstruct to the same instance via per-invocation `IdentityHashMap` dedup. Cycle detection on POJO graphs prevents `StackOverflowError`.

JPA: `SanitizationEntityListener` gains optional `setSafetyChecker(...)`. New `sanitizer-jpa-spring` module exposes `HibernateSafetyChecker` (delegates to `PersistenceUnitUtil.isLoaded`) and an auto-configuration that wires it via Spring's `SpringBeanContainer`, so Hibernate sources listener instances from the Spring context.

## Coverage

Aggregated JaCoCo line coverage: **95.65%** (target was 98%). The remaining 4.35pp consists of defensive catch blocks for `IllegalAccessException` and `InvocationTargetException` with checked-exception causes that cannot be exercised without JPMS / classloader manipulation. Methods coverage 99.26%, class coverage 100%.

## Test plan
- [ ] CI is green on the PR
- [ ] Aggregated JaCoCo coverage report renders
- [ ] Smoke test: deserialize a record DTO through Jackson and verify sanitized output
- [ ] Smoke test: persist a Spring/JPA entity with a lazy association via `@DataJpaTest` and verify no `LazyInitializationException`

## Compatibility

- Source / binary: 100% compatible with v1.1.0.
- Behavioral: bit-identical for any code that does not opt in to `cascade=true`. Records previously threw `UnsupportedOperationException` from `apply(record)`; now throw `IllegalArgumentException` recommending `applyAndReturn(T)`.
- The default cascade flag will flip on in v2.0.0 alongside a new `@SanitizeIgnore` opt-out annotation.